### PR TITLE
Add support for Firefox browser width and height.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Usage
         --html-result <dir>                  output HTML results to specified directory.
      -t,--timeout <timeout>                  set timeout (ms) for waiting. (default: 30000 ms)
         --set-speed <speed>                  same as executing setSpeed(ms) command first.
-        --height <height>                    browser height (only phantomjs)
-        --width <width>                      browser width (only phantomjs)
+        --height <height>                    browser height (only phantomjs and firefox)
+        --width <width>                      browser width (only phantomjs and firefox)
      -D,--define <key=value or key+=value>   define parameters for capabilities. (multiple)
         --rollup <file>                      define rollup rule by JavaScript. (multiple)
      -h,--help                               show this message.

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -178,11 +178,11 @@ public class Main {
             .create());
         options.addOption(OptionBuilder.withLongOpt("height")
             .hasArg().withArgName("height")
-            .withDescription("browser height (only phantomjs)")
+            .withDescription("browser height (only phantomjs and firefox)")
             .create());
         options.addOption(OptionBuilder.withLongOpt("width")
             .hasArg().withArgName("width")
-            .withDescription("browser width (only phantomjs)")
+            .withDescription("browser width (only phantomjs and firefox)")
             .create());
         options.addOption(OptionBuilder.withLongOpt("define")
             .hasArg().withArgName("key=value or key+=value")

--- a/src/main/java/jp/vmi/selenium/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/FirefoxDriverFactory.java
@@ -3,6 +3,8 @@ package jp.vmi.selenium.webdriver;
 import java.io.File;
 import java.util.Map;
 
+import org.apache.commons.lang3.math.NumberUtils;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.firefox.FirefoxBinary;
@@ -10,18 +12,25 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.internal.ProfilesIni;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static jp.vmi.selenium.webdriver.DriverOptions.DriverOption.*;
+import jp.vmi.selenium.webdriver.DriverOptions.DriverOption;
 
 /**
  * Factory of {@link FirefoxDriver}.
  */
 public class FirefoxDriverFactory extends WebDriverFactory {
 
+    private static final Logger log = LoggerFactory.getLogger(FirefoxDriverFactory.class);
+
     /**
      * System property name for specifying Firefox binary.
      */
     public static final String WEBDRIVER_FIREFOX_BIN = "webdriver.firefox.bin";
+    private static final int DEFAULT_WIDTH = 1024;
+    private static final int DEFAULT_HEIGHT = 768;
 
     @Override
     public WebDriver newInstance(DriverOptions driverOptions) {
@@ -61,8 +70,15 @@ public class FirefoxDriverFactory extends WebDriverFactory {
             profile = new FirefoxProfile();
         }
 
+
+
         DesiredCapabilities caps = setupProxy(DesiredCapabilities.firefox(), driverOptions);
         caps.merge(driverOptions.getCapabilities());
-        return new FirefoxDriver(binary, profile, caps);
+        FirefoxDriver driver = new FirefoxDriver(binary, profile, caps);
+        int width = NumberUtils.toInt(driverOptions.get(DriverOption.WIDTH), DEFAULT_WIDTH);
+        int height = NumberUtils.toInt(driverOptions.get(DriverOption.HEIGHT), DEFAULT_HEIGHT);
+        driver.manage().window().setSize(new Dimension(width, height));
+        log.info("firefox screen size: {}x{}", width, height);
+        return driver;
     }
 }


### PR DESCRIPTION
Copied PhantomJS code to set webdriver width and height over to
FirefoxDriverFactory.
