### PR TITLE
Fixed unhandled exception fired  while screensshot is executed. Added bo...

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/inject/ScreenshotInterceptor.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/ScreenshotInterceptor.java
@@ -8,6 +8,7 @@ import jp.vmi.selenium.selenese.Context;
 import jp.vmi.selenium.selenese.ScreenshotHandler;
 import jp.vmi.selenium.selenese.command.ICommand;
 import jp.vmi.selenium.selenese.result.Result;
+import org.openqa.selenium.WebDriverException;
 
 /**
  * Interceptor for screenshot.
@@ -30,12 +31,18 @@ public class ScreenshotInterceptor implements MethodInterceptor {
         if (context instanceof ScreenshotHandler && command.mayUpdateScreen()) {
             ScreenshotHandler handler = (ScreenshotHandler) context;
             String baseName = context.getCurrentTestCase().getBaseName();
+
+            boolean exceptionFired = false;
             try {
                 command.addScreenshot(handler.takeScreenshotAll(baseName, command.getIndex()));
             } catch (NoSuchWindowException e) {
                 // ignore if failed to capturing.
+                exceptionFired = true;
+            } catch (WebDriverException e){
+                // ignore if failed to capturing.
+                exceptionFired = true;
             }
-            if (!result.isSuccess())
+            if (!result.isSuccess() && !exceptionFired)
                 command.addScreenshot(handler.takeScreenshotOnFail(baseName, command.getIndex()));
         }
         return result;


### PR DESCRIPTION
Hello guys,

case A) wait for pop up command execution in the case of pop up not present for the web page selenium fires WebDriverException which is not handled

case B) Once the WebDriverException is fired the result of the command execution is NOT Success  
 if (!result.isSuccess() ) and taking screen shot on fail fails due to the WebDriverException been fired due to the "case A)"

Overall I am very pleased from the project you guys drive and will be very happy if I have the chance to contribute the project.
