### PR TITLE
Add initial width and height for remote driver.

### DIFF
--- a/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
@@ -41,6 +41,7 @@ public class RemoteWebDriverFactory extends WebDriverFactory {
         caps.merge(driverOptions.getCapabilities());
         RemoteWebDriver driver = new RemoteWebDriver(url, caps);
         log.info("Session ID: " + driver.getSessionId());
+        setInitialWindowSize(driver, driverOptions);
         return driver;
     }
 }


### PR DESCRIPTION
The -width and -height arguments had no effect when using -d remote. This change allows for setting the initial dimensions of the remote browser window. Tested with phantomjs:

-d remote --remote-browser phantomjs -width 1024
