### PR TITLE
Added UTF-8 encoding for HtmlResult

### DIFF
--- a/src/main/java/jp/vmi/html/result/HtmlResult.java
+++ b/src/main/java/jp/vmi/html/result/HtmlResult.java
@@ -189,7 +189,7 @@ public class HtmlResult {
         String html = getEngine().transform(getTemplate("result.html"), model);
         File file = new File(htmlResultDir, "TEST-" + testSuite.getName() + ".html");
         try {
-            FileUtils.write(file, html);
+            FileUtils.write(file, html, "UTF-8");
             log.info("Generated HTML result: {}", file);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Added explicit UTF-8 encoding to the HTML result to match the template Content-Type "text/html; charset=UTF-8".

Before this change you had to run the program like this to make sure the correct encoding was used regarldess of the default platform encoding: java -Dfile.encoding=UTF-8 -jar selenese-runner.jar
