### PR TITLE
Add start time and date to HTML report

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/utils/StopWatch.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/StopWatch.java
@@ -112,7 +112,7 @@ public class StopWatch {
      */
 
     public String getStartTimeString() {
-        return new Date(startTime).toString();
+        return new Date(startTimeOfUTC).toString();
     }
 
     /**
@@ -122,6 +122,6 @@ public class StopWatch {
      */
 
     public String getEndTimeString() {
-        return new Date(endTime).toString();
+        return new Date(endTimeOfUTC).toString();
     }
 }

--- a/src/main/resources/jp/vmi/html/result/result.html
+++ b/src/main/resources/jp/vmi/html/result/result.html
@@ -78,7 +78,7 @@ ${if externalJS}<script type="text/javascript" src="${externalJS;u}"></script>${
 
     <table>
       <tr><th>Result:</th><td>${testSuite.result}</td></tr>
-      <tr><th>Start time:</th><td>${testSuite.stopWatch.startTimeString;h}</td></tr>
+      <tr><th>Start time:</th><td>${testSuite.stopWatch.startTimeString}</td></tr>
       <tr><th>Total Time:</th><td>${testSuite.stopWatch.durationString}</td></tr>
       <tr><th>Number of Test Total:</th><td>${numTestTotal}</td></tr>
       <tr><th>Number of Test Passes:</th><td>${numTestPasses}</td></tr>


### PR DESCRIPTION
Patch adds the test start time and date to HTML report, useful when browsing old reports.
