### PR TITLE
Use firefox options for capabilities as well.

### DIFF
--- a/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
@@ -1,5 +1,6 @@
 package jp.vmi.selenium.webdriver;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -12,6 +13,9 @@ import java.util.Map.Entry;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.internal.ProfilesIni;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.google.common.collect.Maps;
@@ -96,6 +100,28 @@ public class DriverOptions {
                 break;
             }
         }
+
+        if (has(DriverOption.PROFILE) || has(DriverOption.PROFILE_DIR)) {
+            // Create FirefoxProfile and set to DesiredCapabilities.
+            // (FirefoxProfile object can work with both local and remote FirefoxDriver
+            //  see: https://code.google.com/p/selenium/wiki/DesiredCapabilities#Firefox_specific)
+            String profileName = get(DriverOption.PROFILE);
+            String dir = get(DriverOption.PROFILE_DIR);
+            FirefoxProfile profile;
+            if (profileName != null) {
+                if (dir != null)
+                    throw new IllegalArgumentException("Can't specify both '--profile' and '--profile-dir' at once");
+                // see http://code.google.com/p/selenium/wiki/TipsAndTricks
+                ProfilesIni allProfiles = new ProfilesIni();
+                profile = allProfiles.getProfile(profileName);
+            } else  {
+                File file = new File(dir);
+                if (!file.isDirectory())
+                    throw new IllegalArgumentException("Missing profile directory: " + dir);
+                profile = new FirefoxProfile(new File(dir));
+            }
+            caps.setCapability(FirefoxDriver.PROFILE, profile);
+        }
     }
 
     /**
@@ -161,10 +187,13 @@ public class DriverOptions {
         default:
             if (values.length != 1)
                 throw new IllegalArgumentException("Need to pass only a single value for " + opt);
-            if (values[0] != null)
+            if (values[0] != null) {
                 map.put(opt, values[0]);
-            else
+                if (opt == DriverOption.FIREFOX)
+                    caps.setCapability(FirefoxDriver.BINARY, values[0]);
+            } else {
                 map.remove(opt);
+            }
             break;
         }
         return this;

--- a/src/main/java/jp/vmi/selenium/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/FirefoxDriverFactory.java
@@ -47,23 +47,10 @@ public class FirefoxDriverFactory extends WebDriverFactory {
             binary.addCommandLineOptions(driverOptions.getCliArgs());
         for (Map.Entry<String, String> entry : driverOptions.getEnvVars().entrySet())
             binary.setEnvironmentProperty(entry.getKey(), entry.getValue());
-        String profileName = driverOptions.get(PROFILE);
-        String dir = driverOptions.get(PROFILE_DIR);
-        FirefoxProfile profile;
-        if (profileName != null) {
-            if (dir != null)
-                throw new IllegalArgumentException("Can't specify both '--profile' and '--profile-dir' at once");
-            // see http://code.google.com/p/selenium/wiki/TipsAndTricks
-            ProfilesIni allProfiles = new ProfilesIni();
-            profile = allProfiles.getProfile(profileName);
-        } else if (dir != null) {
-            File file = new File(dir);
-            if (!file.isDirectory())
-                throw new IllegalArgumentException("Missing profile directory: " + dir);
-            profile = new FirefoxProfile(new File(dir));
-        } else {
+
+        FirefoxProfile profile = (FirefoxProfile) driverOptions.getCapabilities().getCapability(FirefoxDriver.PROFILE);
+        if (profile == null)
             profile = new FirefoxProfile();
-        }
 
         DesiredCapabilities caps = setupProxy(DesiredCapabilities.firefox(), driverOptions);
         caps.merge(driverOptions.getCapabilities());


### PR DESCRIPTION
firefox specific options (--profile, --profire-dir and --firefox) are can be used for RemoteWebDriver
(See https://code.google.com/p/selenium/wiki/DesiredCapabilities#Firefox_specific ), 
I moved creating Firefox profile code from FirefoxDriverFactory to DriverOptinos and added
code to set firefox capabilities to DriverOptions.

This change makes selenese-runner to set firefox capabilities always when firefox options are specified,
but I believe this makes any negative effect since all of the web drivers other than FirefoxDriver may
ignore firefox capabilities.
