### PR TITLE
Don't create RollupRules until necessary

### DIFF
--- a/src/main/java/jp/vmi/selenium/rollup/RollupRules.java
+++ b/src/main/java/jp/vmi/selenium/rollup/RollupRules.java
@@ -48,6 +48,9 @@ public class RollupRules {
      */
     public RollupRules() {
         engine = new ScriptEngineManager().getEngineByExtension("js");
+        // some OpenJDK7 installations have lack of JavaScript support
+        if (engine == null)
+            throw new SeleniumException("Script engine not found for js");
         String engineName = engine.getFactory().getEngineName();
         EngineType engineType = null;
         for (EngineType et : EngineType.values()) {

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -81,7 +81,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private final Deque<CommandListIterator> commandListIteratorStack = new ArrayDeque<CommandListIterator>();
     private VarsMap varsMap = new VarsMap();
     private final CollectionMap collectionMap = new CollectionMap();
-    private final RollupRules rollupRules = new RollupRules();
+    private RollupRules rollupRules; // lazy initialization
     private final Deque<HighlightStyleBackup> styleBackups;
 
     private PageInformation latestPageInformation = PageInformation.EMPTY;
@@ -484,6 +484,9 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
 
     @Override
     public RollupRules getRollupRules() {
+        if (rollupRules == null) {
+            rollupRules = new RollupRules();
+        }
         return rollupRules;
     }
 


### PR DESCRIPTION
OpenJDK7 installed from FreeBSD ports has lack of built-in Javascript ScriptEngine support and
could not be used for running selenese-runner-java due to the NullPointerException.
(I don't test but OpenJDK7 in OpenBSD and DragonflyBSD ports seem to have the same problem)

This PR is a simple workaround for above problem
