### PR TITLE
Bad CSS selector recorded by the Selenium IDE v.2.8.0

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/locator/CSSHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/CSSHandler.java
@@ -1,10 +1,10 @@
 package jp.vmi.selenium.selenese.locator;
 
-import java.util.List;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
+import java.util.List;
 
 class CSSHandler implements LocatorHandler {
 
@@ -15,6 +15,17 @@ class CSSHandler implements LocatorHandler {
 
     @Override
     public List<WebElement> handle(WebDriver driver, String arg) {
-        return driver.findElements(By.cssSelector(arg));
+        return driver.findElements(By.cssSelector(this.fixCssSelector(arg)));
+    }
+
+    protected String fixCssSelector(String cssSelector){
+        /*
+            Selenium IDE records in some cases invalid css selectors which gets fixed once executed by the IDE
+            Example:
+            css=div.tag-1. > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type="text"]
+            needs to be
+            css=div.tag-1 > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type="text"]
+         */
+        return cssSelector.replaceAll("\\. ", " ");
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/locator/CSSHandlerTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/locator/CSSHandlerTest.java
@@ -1,0 +1,33 @@
+package jp.vmi.selenium.selenese.locator;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("javadoc")
+public class CSSHandlerTest {
+
+    @Test
+    public void testCSSSelector() {
+        CSSHandlerExt cssHandlerExt = new CSSHandlerExt();
+
+        assertThat(
+                cssHandlerExt.getFixedCssSelector("css=div.tag-1. > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type=\"text\"]"),
+                is(equalTo("css=div.tag-1 > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type=\"text\"]"))
+        );
+
+        assertThat(
+                cssHandlerExt.getFixedCssSelector("css=div.tag-1 > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type=\"text\"]"),
+                is(equalTo("css=div.tag-1 > div.col-md-12 > div.form-group > div.col-md-5 > div.bootstrap-tagsinput > input[type=\"text\"]"))
+        );
+
+    }
+}
+
+class CSSHandlerExt extends CSSHandler{
+    public String getFixedCssSelector(String cssSelector){
+        return this.fixCssSelector(cssSelector);
+    }
+}


### PR DESCRIPTION
Hello,

Recently I ran into the badly recorded CSS Selector from the Selenium IDE. I have double checked the HTML code is OK. What is even more wired is that the badly recorded CSS selector have been locally executed successfully by the Selenium IDE, but once pushed to webdriver the CSS selector fails with error message element not found (but the element is present).

Thought that will be nice to provide you a fix and also have your opinion about it.
Please note that I have added the exactly recorded CSS selector and the fixed one as comment into the CSSHandler.java class.

Best Regards
Lukian Tabandzhov
