### PR TITLE
add strict-exit-code option to isolate selenese results.

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -35,6 +35,7 @@ public class Main {
     private static final String PROG_TITLE = "Selenese Runner";
 
     private boolean noExit = false;
+    private boolean exitStrictly = false;
     private Integer exitCode = null;
 
     /**
@@ -86,7 +87,10 @@ public class Main {
             setupRunner(runner, config, filenames);
             Result totalResult = runner.run(filenames);
             runner.finish();
-            exitCode = totalResult.getLevel().exitCode;
+            if (exitStrictly)
+                exitCode = totalResult.getLevel().strictExitCode;
+            else
+                exitCode = totalResult.getLevel().exitCode;
         } catch (IllegalArgumentException e) {
             help("Error: " + e.getMessage());
         } catch (Throwable t) {
@@ -182,6 +186,8 @@ public class Main {
         runner.setInitialSpeed(speed);
         if (config.hasOption(NO_EXIT))
             noExit = true;
+        if (config.hasOption(STRICT_EXIT_CODE))
+            exitStrictly = true;
         runner.setPrintStream(System.out);
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
@@ -62,6 +62,7 @@ public class SeleneseRunnerOptions extends Options {
     public static final String COOKIE_FILTER = "cookie-filter";
     public static final String COMMAND_FACTORY = "command-factory";
     public static final String NO_EXIT = "no-exit";
+    public static final String STRICT_EXIT_CODE = "strict-exit-code";
     public static final String HELP = "help";
 
     // default values.
@@ -272,6 +273,9 @@ public class SeleneseRunnerOptions extends Options {
             .create());
         addOption(OptionBuilder.withLongOpt(NO_EXIT)
             .withDescription("don't call System.exit at end.")
+            .create());
+        addOption(OptionBuilder.withLongOpt(STRICT_EXIT_CODE)
+            .withDescription("return strict exit code, reflected by selenese command results at end.")
             .create());
         addOption(OptionBuilder.withLongOpt(HELP)
             .withDescription("show this message.")

--- a/src/main/java/jp/vmi/selenium/selenese/result/Result.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/Result.java
@@ -12,18 +12,20 @@ public abstract class Result implements Comparable<Result> {
      */
     @SuppressWarnings("javadoc")
     public static enum Level {
-        UNEXECUTED(-1, 0),
-        SUCCESS(0, 0),
-        WARNING(1, 0),
-        FAILURE(2, 3),
-        ERROR(3, 3);
+        UNEXECUTED(-1, 0, 4),
+        SUCCESS(0, 0, 0),
+        WARNING(1, 0, 5),
+        FAILURE(2, 3, 3),
+        ERROR(3, 3, 6);
 
         public final int value;
         public final int exitCode;
+        public final int strictExitCode;
 
-        private Level(int value, int exitCode) {
+        private Level(int value, int exitCode, int strictExitCode) {
             this.value = value;
             this.exitCode = exitCode;
+            this.strictExitCode = strictExitCode;
         }
     }
 


### PR DESCRIPTION
In the current implementation, selense-runner-java keeps selensese command results, UNEXECUTED/SUCCESS/WARNING/FAILURE/ERROR, however exit code returns the following status:

* 0 for UNEXECUTED/SUCCESS/WARNING
* 1 for command line parse error
* 3 to represent FAILURE/ERROR

This pull request adds the `--strict-exit-code` option that make selenese-runner-java to return exit code reflected by command results.
With this changes, we could isolate causes on scenario execution with exit codes of selenese-runner-java.

I tried out the following exit code:

* 0 for SUCCESS, unchanged
* 1 for command line parse error, unchanged
* 3 for FAILURE, unchanged
* 4 for UNEXECUTED, changed
* 5 for WARNING, changed
* 6 for ERROR, changed

When one put both `--no-exit` and `--strict-exit-code`, `--no-exit` overcomes `--strict-exit-code` for backward compatibility.

Best regards