### PR TITLE
add command line options to support Chrome-specific capability

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
@@ -36,7 +36,7 @@ public class SeleneseRunnerOptions extends Options {
     public static final String DRIVER = "driver";
     public static final String PROFILE = "profile";
     public static final String PROFILE_DIR = "profile-dir";
-    public static final String CHROME_EXTENSIONS = "chrome-extensions";
+    public static final String CHROME_EXTENSION = "chrome-extension";
     public static final String CHROME_EXPERIMENTAL_OPTIONS = "chrome-experimental-options";
     public static final String PROXY = "proxy";
     public static final String PROXY_USER = "proxy-user";
@@ -179,7 +179,7 @@ public class SeleneseRunnerOptions extends Options {
             .hasArg().withArgName("file")
             .withDescription("path to json file specify experimental options for chrome (Chrome only *1)")
             .create());
-        addOption(OptionBuilder.withLongOpt(CHROME_EXTENSIONS)
+        addOption(OptionBuilder.withLongOpt(CHROME_EXTENSION)
             .hasArg().withArgName("file")
             .withDescription("chrome extension file (Chrome only *1)")
             .create());

--- a/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
@@ -36,6 +36,8 @@ public class SeleneseRunnerOptions extends Options {
     public static final String DRIVER = "driver";
     public static final String PROFILE = "profile";
     public static final String PROFILE_DIR = "profile-dir";
+    public static final String CHROME_EXTENSIONS = "chrome-extensions";
+    public static final String CHROME_EXPERIMENTAL_OPTIONS = "chrome-experimental-options";
     public static final String PROXY = "proxy";
     public static final String PROXY_USER = "proxy-user";
     public static final String PROXY_PASSWORD = "proxy-password";
@@ -173,6 +175,14 @@ public class SeleneseRunnerOptions extends Options {
             .hasArg().withArgName("dir")
             .withDescription("profile directory (Firefox only *1)")
             .create('P'));
+        addOption(OptionBuilder.withLongOpt(CHROME_EXPERIMENTAL_OPTIONS)
+            .hasArg().withArgName("file")
+            .withDescription("path to json file specify experimental options for chrome (Chrome only *1)")
+            .create());
+        addOption(OptionBuilder.withLongOpt(CHROME_EXTENSIONS)
+            .hasArg().withArgName("file")
+            .withDescription("chrome extension file (Chrome only *1)")
+            .create());
         addOption(OptionBuilder.withLongOpt(PROXY)
             .hasArg().withArgName("proxy")
             .withDescription("proxy host and port (HOST:PORT) (excepting IE)")

--- a/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
@@ -37,7 +37,7 @@ public class ChromeDriverFactory extends WebDriverFactory {
             options.addArguments("--proxy-server=http://" + driverOptions.get(PROXY));
         if (driverOptions.has(CLI_ARGS))
             options.addArguments(driverOptions.getCliArgs());
-        if (driverOptions.has(CHROME_EXTENSIONS))
+        if (driverOptions.has(CHROME_EXTENSION))
             options.addExtensions(driverOptions.getChromeExtensions());
         String experimentalOptions = driverOptions.get(CHROME_EXPERIMENTAL_OPTIONS);
         if (experimentalOptions != null) {

--- a/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
@@ -1,7 +1,13 @@
 package jp.vmi.selenium.webdriver;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Iterator;
 
+import com.google.common.io.Files;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -19,6 +25,49 @@ import static jp.vmi.selenium.webdriver.DriverOptions.DriverOption.*;
  */
 public class ChromeDriverFactory extends WebDriverFactory {
 
+    /**
+     * set driver specific capabilities.
+     *
+     * @param caps desired capabilities.
+     * @param driverOptions driver options.
+     */
+    public static void setDriverSpecificCapabilities(DesiredCapabilities caps, DriverOptions driverOptions) throws RuntimeException{
+        ChromeOptions options = new ChromeOptions();
+        if (driverOptions.has(PROXY))
+            options.addArguments("--proxy-server=http://" + driverOptions.get(PROXY));
+        if (driverOptions.has(CLI_ARGS))
+            options.addArguments(driverOptions.getCliArgs());
+        if (driverOptions.has(CHROME_EXTENSIONS))
+            options.addExtensions(driverOptions.getChromeExtensions());
+        String experimentalOptions = driverOptions.get(CHROME_EXPERIMENTAL_OPTIONS);
+        if (experimentalOptions != null) {
+            String json = "{}";
+            try {
+                json = Files.toString(new File(experimentalOptions), Charset.defaultCharset());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            JSONObject jsonObject;
+            try {
+                jsonObject = new JSONObject(json);
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+            @SuppressWarnings("unchecked")
+            Iterator<String> keys = jsonObject.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                try {
+                    options.setExperimentalOption(key, jsonObject.get(key));
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        caps.setCapability(ChromeOptions.CAPABILITY, options);
+        caps.merge(driverOptions.getCapabilities());
+    }
+
     @Override
     public WebDriver newInstance(DriverOptions driverOptions) {
         DesiredCapabilities caps = DesiredCapabilities.chrome();
@@ -29,13 +78,7 @@ public class ChromeDriverFactory extends WebDriverFactory {
             System.setProperty(ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY, executable);
         }
         ChromeDriverService service = CustomChromeDriverService.createService(driverOptions.getEnvVars());
-        ChromeOptions options = new ChromeOptions();
-        if (driverOptions.has(PROXY))
-            options.addArguments("--proxy-server=http://" + driverOptions.get(PROXY));
-        if (driverOptions.has(CLI_ARGS))
-            options.addArguments(driverOptions.getCliArgs());
-        caps.setCapability(ChromeOptions.CAPABILITY, options);
-        caps.merge(driverOptions.getCapabilities());
+        setDriverSpecificCapabilities(caps, driverOptions);
         ChromeDriver driver = new ChromeDriver(service, caps);
         setInitialWindowSize(driver, driverOptions);
         return driver;

--- a/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
@@ -8,6 +8,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.lang3.ArrayUtils;
@@ -67,11 +68,16 @@ public class DriverOptions {
         DEFINE,
         /** --cli-args */
         CLI_ARGS,
+        /** --chrome-extensions */
+        CHROME_EXTENSIONS,
+        /** --chrome-experimental-options */
+        CHROME_EXPERIMENTAL_OPTIONS,
     }
 
     private final IdentityHashMap<DriverOptions.DriverOption, String> map = Maps.newIdentityHashMap();
     private final DesiredCapabilities caps = new DesiredCapabilities();
     private String[] cliArgs = ArrayUtils.EMPTY_STRING_ARRAY;
+    private List<File> chromeExtensions = new ArrayList<File>();
     private final HashMap<String, String> envVars = Maps.newHashMap();
 
     /**
@@ -106,6 +112,13 @@ public class DriverOptions {
                 if (config.hasOption(key))
                     cliArgs = config.getOptionValues(key);
                 break;
+            case CHROME_EXTENSIONS:
+                if (config.hasOption(key)) {
+                    for (String ext : config.getOptionValues(key)) {
+                        chromeExtensions.add(new File(ext));
+                    }
+                }
+                break;
             default:
                 set(opt, config.getOptionValue(key));
                 break;
@@ -122,6 +135,7 @@ public class DriverOptions {
         map.putAll(other.map);
         caps.merge(other.caps);
         cliArgs = other.cliArgs;
+        chromeExtensions = other.chromeExtensions;
         envVars.putAll(other.envVars);
     }
 
@@ -137,6 +151,8 @@ public class DriverOptions {
             throw new IllegalArgumentException("Need to use DriverOptions#getCapabilities() instead of get(DriverOption.DEFINE).");
         case CLI_ARGS:
             throw new IllegalArgumentException("Need to use DriverOptions#getExtraOptions() instead of get(DriverOption.CLI_ARGS).");
+        case CHROME_EXTENSIONS:
+            throw new IllegalArgumentException("Need to use DriverOptions#getExtraOptions() instead of get(DriverOption.CHROME_EXTENSIONS).");
         default:
             return map.get(opt);
         }
@@ -154,6 +170,8 @@ public class DriverOptions {
             return !caps.asMap().isEmpty();
         case CLI_ARGS:
             return cliArgs.length != 0;
+        case CHROME_EXTENSIONS:
+            return !chromeExtensions.isEmpty();
         default:
             return map.containsKey(opt);
         }
@@ -173,6 +191,11 @@ public class DriverOptions {
             break;
         case CLI_ARGS:
             cliArgs = ArrayUtils.addAll(cliArgs, values);
+            break;
+        case CHROME_EXTENSIONS:
+            for (String ext : values) {
+                chromeExtensions.add(new File(ext));
+            }
             break;
         default:
             if (values.length != 1)
@@ -230,6 +253,16 @@ public class DriverOptions {
         return cliArgs;
     }
 
+
+    /**
+     * Get Chrome Extensions for starting up driver.
+     *
+     * @return Chrome Extension files.
+     */
+    public List<File> getChromeExtensions() {
+        return chromeExtensions;
+    }
+
     /**
      * Get environment variables map.
      *
@@ -262,6 +295,14 @@ public class DriverOptions {
                         result.append(opt.name()).append('=');
                         for (String extraOption : cliArgs)
                             result.append(extraOption).append(',');
+                        result.setCharAt(result.length() - 1, '|');
+                    }
+                    break;
+                case CHROME_EXTENSIONS:
+                    if (!chromeExtensions.isEmpty()) {
+                        result.append(opt.name()).append('=');
+                        for (File extraOption : chromeExtensions)
+                            result.append(extraOption.toString()).append(',');
                         result.setCharAt(result.length() - 1, '|');
                     }
                     break;

--- a/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
@@ -68,8 +68,8 @@ public class DriverOptions {
         DEFINE,
         /** --cli-args */
         CLI_ARGS,
-        /** --chrome-extensions */
-        CHROME_EXTENSIONS,
+        /** --chrome-extension */
+        CHROME_EXTENSION,
         /** --chrome-experimental-options */
         CHROME_EXPERIMENTAL_OPTIONS,
     }
@@ -112,7 +112,7 @@ public class DriverOptions {
                 if (config.hasOption(key))
                     cliArgs = config.getOptionValues(key);
                 break;
-            case CHROME_EXTENSIONS:
+            case CHROME_EXTENSION:
                 if (config.hasOption(key)) {
                     for (String ext : config.getOptionValues(key)) {
                         chromeExtensions.add(new File(ext));
@@ -151,8 +151,8 @@ public class DriverOptions {
             throw new IllegalArgumentException("Need to use DriverOptions#getCapabilities() instead of get(DriverOption.DEFINE).");
         case CLI_ARGS:
             throw new IllegalArgumentException("Need to use DriverOptions#getExtraOptions() instead of get(DriverOption.CLI_ARGS).");
-        case CHROME_EXTENSIONS:
-            throw new IllegalArgumentException("Need to use DriverOptions#getExtraOptions() instead of get(DriverOption.CHROME_EXTENSIONS).");
+        case CHROME_EXTENSION:
+            throw new IllegalArgumentException("Need to use DriverOptions#getExtraOptions() instead of get(DriverOption.CHROME_EXTENSION).");
         default:
             return map.get(opt);
         }
@@ -170,7 +170,7 @@ public class DriverOptions {
             return !caps.asMap().isEmpty();
         case CLI_ARGS:
             return cliArgs.length != 0;
-        case CHROME_EXTENSIONS:
+        case CHROME_EXTENSION:
             return !chromeExtensions.isEmpty();
         default:
             return map.containsKey(opt);
@@ -192,7 +192,7 @@ public class DriverOptions {
         case CLI_ARGS:
             cliArgs = ArrayUtils.addAll(cliArgs, values);
             break;
-        case CHROME_EXTENSIONS:
+        case CHROME_EXTENSION:
             for (String ext : values) {
                 chromeExtensions.add(new File(ext));
             }
@@ -298,7 +298,7 @@ public class DriverOptions {
                         result.setCharAt(result.length() - 1, '|');
                     }
                     break;
-                case CHROME_EXTENSIONS:
+                case CHROME_EXTENSION:
                     if (!chromeExtensions.isEmpty()) {
                         result.append(opt.name()).append('=');
                         for (File extraOption : chromeExtensions)

--- a/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
@@ -30,6 +30,8 @@ public class RemoteWebDriverFactory extends WebDriverFactory {
             log.info("Remote browser: {}", browser);
             if ("firefox".equalsIgnoreCase(browser))
                 FirefoxDriverFactory.setDriverSpecificCapabilities(caps, driverOptions, true);
+            if ("chrome".equalsIgnoreCase(browser))
+                ChromeDriverFactory.setDriverSpecificCapabilities(caps, driverOptions);
         }
         if (driverOptions.has(REMOTE_PLATFORM)) {
             String platform = driverOptions.get(REMOTE_PLATFORM);


### PR DESCRIPTION
This pull request adds following command line options:

- `--chrome-experimental-options` option to specify path to json file
  describe various objects in ChromeOptions

  ```console
  $ java -jar selenese-runner.jar --driver chrome --chrome-exprerimental-options /path/to/chromeoptions.json
  ```

  The contents of chromeoptions.json seems:

  ```json
  {
      "prefs": {
          ...
      }
  }
  ```

  or following (to test with Chrome on Android)

  ```json
  {
      "androidPackage": "com.android.chrome" 
  }
  ```

- `--chrome-extensions` option to specify chrome extension crx files

  ```console
  $ java -jar selenese-runner.jar --driver chrome --chrome-extensions /path/to/extension.crx
  ```

With this changes, one can use selenese-runner-java to test

- with configured Chrome
- with Chrome on Android
- Chrome extension behavior 

I choose JSON format to describe objects in ChromeOptions because they might be dictionaries(Map) not only strings(firstly I tried out with `define` option, but can't describe data structure like a dictionary).

The naming of `--chrome-experimental-options` is simply due to the naming of [upstream selenium client manner](https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/chrome/ChromeOptions.java#L77).

I had tested these options in chromedriver and remote chromedriver.

For reference, available Chrome options are listed in
- general options [Capabilities & ChromeOptions - ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/capabilities)
- Android-specific options [Getting Started Android - ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/getting-started/getting-started---android)
