### PR TITLE
RollupManager - args Object Array will now work also with Java1.8.51+

### DIFF
--- a/src/main/java/jp/vmi/script/JSList.java
+++ b/src/main/java/jp/vmi/script/JSList.java
@@ -23,7 +23,7 @@ public abstract class JSList<E> extends AbstractList<E> {
     public abstract Object unwrap();
 
     // for Nashorn.
-    static class JSMapList<E> extends JSList<E> {
+    public static class JSMapList<E> extends JSList<E> {
 
         private final Map<?, E> map;
 

--- a/src/main/java/jp/vmi/selenium/rollup/RollupManager.java
+++ b/src/main/java/jp/vmi/selenium/rollup/RollupManager.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.thoughtworks.selenium.SeleniumException;
 
 import jp.vmi.script.JSList;
+import jp.vmi.script.JSList.JSMapList;
 import jp.vmi.script.JSMap;
 
 /**
@@ -51,8 +52,12 @@ public class RollupManager {
         log.info("- Description: {}", ruleMap.get("description"));
         List<Object> args = JSList.toList(engine, ruleMap.get("args"));
         if (args != null && args.size() > 0) {
+            JSMapList<Object> jsMap = (JSMapList<Object>) args;
+            Map<Object, Object> mapa = (Map<Object, Object>) (jsMap.unwrap());
+
             log.info("- Arguments:");
-            for (Object arg : args) {
+            for (Object key : mapa.keySet()) {
+                Object arg = mapa.get(key);
                 Map<?, ?> argMap = JSMap.toMap(engine, arg);
                 log.info("  + {}: {}", argMap.get("name"), argMap.get("description"));
             }


### PR DESCRIPTION
When adding a rollup rule, nasshorn was not able to parse args object arrays. 
On Java versions 1.8.51+ it was throwing an exception (Lower 1.8 versions were fine): 
```
java.lang.ClassCastException: key should be a String. It is java.lang.Integer instead.
        at jdk.nashorn.api.scripting.ScriptObjectMirror.checkKey(ScriptObjectMirror.java:885)
        at jdk.nashorn.api.scripting.ScriptObjectMirror.get(ScriptObjectMirror.java:382)
        at jp.vmi.script.JSList$JSMapList.get(JSList.java:37)
        at java.util.AbstractList$Itr.next(AbstractList.java:358)
        at jp.vmi.selenium.rollup.RollupManager.addRollupRule(RollupManager.java:55)
```
This is the javascript (was failing on args array):
```javascript
manager.addRollupRule({
    name: "spot_type",
    description: "Sets value 'text' to 'element'",
    args: [{
        name: "text",
        description: "Text value"
    }, {
        name: "element",
        description: "Element locator"
    }],
    commandMatchers: [],
    getExpandedCommands: function(args) {
        var commands = [];

        commands.push({
            command: "waitForElementPresent",
            target: args.element
        });
        commands.push({
            command: "type",
            target: args.element,
            value: args.text
        });

        return commands;
    }
});
```

With this commit the issue is fixed. It works for 1.8.51+ Java versions. 


