### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/inject/Binder.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/Binder.java
@@ -18,6 +18,9 @@ public class Binder {
 
     private static Injector injector = Guice.createInjector(new BindModule());
 
+    private Binder() {
+    }
+
     /**
      * Replace customized BindModule.
      *

--- a/src/main/java/jp/vmi/selenium/selenese/utils/CommandDumper.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/CommandDumper.java
@@ -27,6 +27,9 @@ public class CommandDumper {
 
     private static final Pattern GETTER = Pattern.compile("(get|is)([A-Z].*)");
 
+    private CommandDumper() {
+    }
+
     private static String append(String s1, String s2) {
         if (StringUtils.isEmpty(s1))
             return s2;

--- a/src/main/java/jp/vmi/selenium/selenese/utils/DateTimeUtils.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/DateTimeUtils.java
@@ -15,6 +15,9 @@ public final class DateTimeUtils {
         setFormat("yyyy-MM-dd", " ", "HH:mm:ss", ".SSS", " ", "ZZ");
     }
 
+    private DateTimeUtils() {
+    }
+
     /**
      * Set date and time format.
      *

--- a/src/main/java/jp/vmi/selenium/selenese/utils/PathUtils.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/PathUtils.java
@@ -17,6 +17,9 @@ public class PathUtils {
     private static final String SEP_REPL = Matcher.quoteReplacement(File.separator);
     private static final String PARENT_DIR = ".." + File.separator;
 
+    private PathUtils() {
+    }
+
     private static String normalizeInternal(String filename) {
         if (filename.startsWith(PARENT_DIR))
             filename = new File(filename).getAbsolutePath();

--- a/src/main/java/jp/vmi/selenium/selenese/utils/SeleniumUtils.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/SeleniumUtils.java
@@ -12,6 +12,9 @@ import org.apache.commons.lang3.math.NumberUtils;
  */
 public class SeleniumUtils {
 
+    private SeleniumUtils() {
+    }
+
     /**
      * string-matching pattern of SeleniumIDE.
      */

--- a/src/main/java/org/openqa/selenium/browserlaunchers/Proxies.java
+++ b/src/main/java/org/openqa/selenium/browserlaunchers/Proxies.java
@@ -13,6 +13,9 @@ import org.openqa.selenium.Proxy;
 @SuppressWarnings("javadoc")
 public class Proxies {
 
+    private Proxies() {
+    }
+
     public static Proxy extractProxy(Capabilities desiredCapabilities) {
         return Proxy.extractFrom(desiredCapabilities);
     }

--- a/src/main/java/org/openqa/selenium/phantomjs/CustomPhantomJSDriverServiceFactory.java
+++ b/src/main/java/org/openqa/selenium/phantomjs/CustomPhantomJSDriverServiceFactory.java
@@ -57,6 +57,9 @@ public class CustomPhantomJSDriverServiceFactory {
     private static final String GHOSTDRIVER_DOC_LINK = "https://github.com/detro/ghostdriver/blob/master/README.md";
     private static final String GHOSTDRIVER_DOWNLOAD_LINK = "https://github.com/detro/ghostdriver/downloads";
 
+    private CustomPhantomJSDriverServiceFactory() {
+    }
+
     /**
      * Configures and returns a new {@link PhantomJSDriverService} using the default configuration without logging.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.