### PR TITLE
 Objects should not be created only to "getClass"

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -65,15 +65,13 @@ public class CommandList extends ArrayList<ICommand> {
     @Deprecated
     @Override
     public CommandListIterator listIterator(int index) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Deprecated
     @Override
     public CommandListIterator listIterator() {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/result/CommandResultList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/CommandResultList.java
@@ -136,75 +136,63 @@ public class CommandResultList implements List<CommandResult> {
 
     @Override
     public CommandResult set(int index, CommandResult element) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public void add(int index, CommandResult element) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
 
     }
 
     @Override
     public int indexOf(Object o) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public int lastIndexOf(Object o) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean contains(Object o) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean containsAll(Collection<?> c) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean addAll(int index, Collection<? extends CommandResult> c) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public CommandResult remove(int index) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean remove(Object o) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public void clear() {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
 }

--- a/src/main/java/jp/vmi/selenium/selenese/result/CommandResultMap.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/CommandResultMap.java
@@ -98,25 +98,21 @@ public class CommandResultMap implements Map<ICommand, List<CommandResult>> {
 
     @Override
     public List<CommandResult> put(ICommand key, List<CommandResult> value) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public void putAll(Map<? extends ICommand, ? extends List<CommandResult>> m) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public List<CommandResult> remove(Object key) {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 
     @Override
     public void clear() {
-        throw new UnsupportedOperationException(new Object() {
-        }.getClass().getEnclosingMethod().toString());
+        throw new UnsupportedOperationException(Object.class.getEnclosingMethod().toString());
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2133 - “ Objects should not be created only to "getClass" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2133
Please let me know if you have any questions.
Ayman Abdelghany.