### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/jp/vmi/html/result/HtmlResult.java
+++ b/src/main/java/jp/vmi/html/result/HtmlResult.java
@@ -177,7 +177,7 @@ public class HtmlResult {
                 break;
             }
         }
-        Map<String, Object> model = new HashMap<String, Object>();
+        Map<String, Object> model = new HashMap<>();
         model.put("title", testSuite.getName() + " results");
         model.put("sysInfo", SystemInformation.getInstance());
         model.put("testSuite", testSuite);
@@ -212,7 +212,7 @@ public class HtmlResult {
     public void generateIndex() {
         if (htmlResultDir == null)
             return;
-        Map<String, Object> model = new HashMap<String, Object>();
+        Map<String, Object> model = new HashMap<>();
         model.put("title", "Index of test-suite results.");
         model.put("tree", tree);
         String html = getEngine().transform(getTemplate("index.html"), model);

--- a/src/main/java/jp/vmi/html/result/NodeRenderer.java
+++ b/src/main/java/jp/vmi/html/result/NodeRenderer.java
@@ -29,7 +29,7 @@ public class NodeRenderer implements Renderer<Node> {
 
     @Override
     public String render(Node node, Locale locale) {
-        HashMap<String, Object> model = new HashMap<String, Object>();
+        HashMap<String, Object> model = new HashMap<>();
         model.put("node", node);
         return engine.transform(template, model);
     }

--- a/src/main/java/jp/vmi/html/result/TestSuiteTree.java
+++ b/src/main/java/jp/vmi/html/result/TestSuiteTree.java
@@ -19,7 +19,7 @@ public class TestSuiteTree {
         public Node parent = null;
         public final TestSuite testSuite;
         public final TestSuiteSummary summary;
-        public final List<Node> children = new ArrayList<Node>();
+        public final List<Node> children = new ArrayList<>();
 
         private Node(Node parent, TestSuite testSuite, TestSuiteSummary summary) {
             this.parent = parent;
@@ -29,7 +29,7 @@ public class TestSuiteTree {
     }
 
     private final Node root = new Node(null, null, null);
-    private final Map<TestSuite, Node> map = new HashMap<TestSuite, Node>();
+    private final Map<TestSuite, Node> map = new HashMap<>();
 
     /**
      * Get test-suite result summary.

--- a/src/main/java/jp/vmi/junit/result/JUnitResult.java
+++ b/src/main/java/jp/vmi/junit/result/JUnitResult.java
@@ -47,7 +47,7 @@ public final class JUnitResult {
 
     private final JAXBContext context = initContext();
 
-    private final Map<Object, TestResult<?>> map = new ConcurrentHashMap<Object, TestResult<?>>();
+    private final Map<Object, TestResult<?>> map = new ConcurrentHashMap<>();
 
     private final FailsafeSummary failsafeSummary = factory.createFailsafeSummary();
 

--- a/src/main/java/jp/vmi/junit/result/TestSuiteResult.java
+++ b/src/main/java/jp/vmi/junit/result/TestSuiteResult.java
@@ -31,13 +31,13 @@ public class TestSuiteResult extends TestResult<ITestSuite> {
 
     @XmlElementWrapper
     @XmlElement(name = "property")
-    private final List<Property> properties = new ArrayList<Property>();
+    private final List<Property> properties = new ArrayList<>();
 
     @XmlElement
     private TestCaseResult error;
 
     @XmlElement(name = "testcase")
-    private final List<TestCaseResult> testCaseResults = new ArrayList<TestCaseResult>();
+    private final List<TestCaseResult> testCaseResults = new ArrayList<>();
 
     /**
      * Add property.

--- a/src/main/java/jp/vmi/script/JSList.java
+++ b/src/main/java/jp/vmi/script/JSList.java
@@ -89,8 +89,8 @@ public abstract class JSList<E> extends AbstractList<E> {
         else if (object instanceof List)
             return (List<E>) object; // for Rhino in Java7.
         else if (object instanceof Map)
-            return new JSMapList<E>(object);
+            return new JSMapList<>(object);
         else
-            return new JSNativeList<E>(engine, object);
+            return new JSNativeList<>(engine, object);
     }
 }

--- a/src/main/java/jp/vmi/script/JSMap.java
+++ b/src/main/java/jp/vmi/script/JSMap.java
@@ -42,7 +42,7 @@ public class JSMap<K, V> extends AbstractMap<K, V> {
 
     @Override
     public Set<Entry<K, V>> entrySet() {
-        final Set<Entry<K, V>> result = new HashSet<Entry<K, V>>();
+        final Set<Entry<K, V>> result = new HashSet<>();
         wrapper.eval("for (var k in " + OBJECT + ") {"
             + "  if (" + OBJECT + ".hasOwnProperty(k)) {"
             + "    " + ARGS + "[0].execute(k, " + OBJECT + "[k]);"
@@ -51,7 +51,7 @@ public class JSMap<K, V> extends AbstractMap<K, V> {
             new EntrySetCallback<K, V>() {
                 @Override
                 public void execute(K key, V value) {
-                    result.add(new SimpleEntry<K, V>(key, value));
+                    result.add(new SimpleEntry<>(key, value));
                 }
             });
         return result;
@@ -82,6 +82,6 @@ public class JSMap<K, V> extends AbstractMap<K, V> {
         else if (object instanceof Map)
             return (Map<K, V>) object; // for Rhino in Java7 and Nashorn.
         else
-            return new JSMap<K, V>(engine, object);
+            return new JSMap<>(engine, object);
     }
 }

--- a/src/main/java/jp/vmi/selenium/rollup/RollupRules.java
+++ b/src/main/java/jp/vmi/selenium/rollup/RollupRules.java
@@ -41,7 +41,7 @@ public class RollupRules {
 
     final ScriptEngine engine;
     final EngineType engineType;
-    private final Map<String, RollupRule> rollupRules = new HashMap<String, RollupRule>();
+    private final Map<String, RollupRule> rollupRules = new HashMap<>();
 
     /**
      * Constructor.

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -78,7 +78,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private final WebDriverElementFinder elementFinder;
     private final CommandFactory commandFactory;
     private TestCase currentTestCase = null;
-    private final Deque<CommandListIterator> commandListIteratorStack = new ArrayDeque<CommandListIterator>();
+    private final Deque<CommandListIterator> commandListIteratorStack = new ArrayDeque<>();
     private VarsMap varsMap = new VarsMap();
     private final CollectionMap collectionMap = new CollectionMap();
     private RollupRules rollupRules = null; // lazy initialization
@@ -100,7 +100,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
         this.subCommandMap = new SubCommandMap(this);
         this.commandFactory = new CommandFactory(this);
         this.varsMap = new VarsMap();
-        this.styleBackups = new ArrayDeque<HighlightStyleBackup>();
+        this.styleBackups = new ArrayDeque<>();
     }
 
     /**
@@ -576,7 +576,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
      */
     public Result run(String... filenames) {
         Result totalResult = UNEXECUTED;
-        List<TestSuite> testSuiteList = new ArrayList<TestSuite>();
+        List<TestSuite> testSuiteList = new ArrayList<>();
         for (String filename : filenames) {
             Selenese selenese = Parser.parse(filename, commandFactory);
             Parser.setContextForBackwardCompatibility(selenese, this);

--- a/src/main/java/jp/vmi/selenium/selenese/TestCase.java
+++ b/src/main/java/jp/vmi/selenium/selenese/TestCase.java
@@ -44,7 +44,7 @@ public class TestCase implements Selenese, ITestCase, IHtmlResultTestCase {
     private String baseURL = null;
 
     private StartLoop currentStartLoop = NO_START_LOOP;
-    private final Deque<StartLoop> loopCommandStack = new ArrayDeque<StartLoop>();
+    private final Deque<StartLoop> loopCommandStack = new ArrayDeque<>();
     private final CommandList commandList = Binder.newCommandList();
     private final CommandResultList cresultList = new CommandResultList();
 

--- a/src/main/java/jp/vmi/selenium/selenese/TestCaseParser.java
+++ b/src/main/java/jp/vmi/selenium/selenese/TestCaseParser.java
@@ -50,14 +50,14 @@ public class TestCaseParser extends Parser {
                 List<String> cmdWithArgs;
                 switch (tr.getNodeType()) {
                 case Node.ELEMENT_NODE: // TD
-                    cmdWithArgs = new ArrayList<String>(3);
+                    cmdWithArgs = new ArrayList<>(3);
                     for (Node td : each(tr.getChildNodes())) {
                         if ("TD".equals(td.getNodeName()))
                             cmdWithArgs.add(getTdString(td));
                     }
                     break;
                 case Node.COMMENT_NODE:
-                    cmdWithArgs = new ArrayList<String>(2);
+                    cmdWithArgs = new ArrayList<>(2);
                     cmdWithArgs.add("comment");
                     cmdWithArgs.add(tr.getNodeValue().trim());
                     break;

--- a/src/main/java/jp/vmi/selenium/selenese/TestSuite.java
+++ b/src/main/java/jp/vmi/selenium/selenese/TestSuite.java
@@ -32,7 +32,7 @@ public class TestSuite implements Selenese, ITestSuite, IHtmlResultTestSuite {
 
     private String parentDir = null;
     private String webDriverName = null;
-    private final List<Selenese> seleneseList = new ArrayList<Selenese>();
+    private final List<Selenese> seleneseList = new ArrayList<>();
 
     private final StopWatch stopWatch = new StopWatch();
     private Result result = UNEXECUTED;

--- a/src/main/java/jp/vmi/selenium/selenese/command/AbstractCommand.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/AbstractCommand.java
@@ -165,7 +165,7 @@ public abstract class AbstractCommand implements ICommand {
         if (path == null)
             return;
         if (screenshots == null)
-            screenshots = new ArrayList<Screenshot>();
+            screenshots = new ArrayList<>();
         screenshots.add(new Screenshot(path, label));
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/command/Command.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Command.java
@@ -250,7 +250,7 @@ public abstract class Command implements ICommand {
         if (path == null)
             return;
         if (screenshots == null)
-            screenshots = new ArrayList<Screenshot>();
+            screenshots = new ArrayList<>();
         screenshots.add(new Screenshot(path, label));
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
@@ -26,7 +26,7 @@ import jp.vmi.selenium.selenese.subcommand.SubCommandMap;
 @SuppressWarnings("deprecation")
 public class CommandFactory implements ICommandFactory {
 
-    private static final Map<String, Constructor<? extends ICommand>> constructorMap = new HashMap<String, Constructor<? extends ICommand>>();
+    private static final Map<String, Constructor<? extends ICommand>> constructorMap = new HashMap<>();
 
     private static void addConstructor(Class<? extends ICommand> cmdClass, String... aliases) {
         try {
@@ -86,7 +86,7 @@ public class CommandFactory implements ICommandFactory {
     private static final int IS_PRESENT_INVERSE = 4;
     private static final int PRESENT = 5;
 
-    private final List<ICommandFactory> commandFactories = new ArrayList<ICommandFactory>();
+    private final List<ICommandFactory> commandFactories = new ArrayList<>();
 
     private Context context = null;
 

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -22,7 +22,7 @@ public class CommandList extends ArrayList<ICommand> {
 
     private static final long serialVersionUID = 1L;
 
-    private final Map<Object, Integer> indexCache = new HashMap<Object, Integer>();
+    private final Map<Object, Integer> indexCache = new HashMap<>();
 
     @Override
     public boolean add(ICommand command) {
@@ -159,7 +159,7 @@ public class CommandList extends ArrayList<ICommand> {
                 if (ss == null || prevSSIndex == ss.size())
                     newSS = null;
                 else
-                    newSS = new ArrayList<Screenshot>(ss.subList(prevSSIndex, ss.size()));
+                    newSS = new ArrayList<>(ss.subList(prevSSIndex, ss.size()));
                 CommandResult cresult = new CommandResult(sequence.toString(), command, newSS, result, cresultList.getEndTime(), System.currentTimeMillis());
                 cresultList.add(cresult);
 

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandSequence.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandSequence.java
@@ -24,7 +24,7 @@ public class CommandSequence {
     }
 
     private final CommandSequence parent;
-    private final List<Counter> counters = new ArrayList<Counter>();
+    private final List<Counter> counters = new ArrayList<>();
     private Counter tail;
 
     /**
@@ -41,7 +41,7 @@ public class CommandSequence {
         List<StartLoop> result;
         StartLoop startLoop = command.getStartLoop();
         if (startLoop == StartLoop.NO_START_LOOP)
-            result = new ArrayList<StartLoop>();
+            result = new ArrayList<>();
         else
             result = getListOfStartLoop((ICommand) startLoop);
         result.add(startLoop);

--- a/src/main/java/jp/vmi/selenium/selenese/command/Rollup.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Rollup.java
@@ -43,7 +43,7 @@ public class Rollup extends AbstractCommand {
     }
 
     private Map<String, String> parseKwArgs(String kwArgs) {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         Matcher matcher = RE_KW_ARGS.matcher(kwArgs.trim());
         while (matcher.find()) {
             String name = matcher.group(MG_NAME);

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 public class DefaultConfig implements IConfig {
 
     private final CommandLine cli;
-    private final Map<String, List<String>> config = new HashMap<String, List<String>>();
+    private final Map<String, List<String>> config = new HashMap<>();
 
     /**
      * Constructor.
@@ -82,7 +82,7 @@ public class DefaultConfig implements IConfig {
                 String key = matcher.group(1);
                 if (key != null) {
                     currentKey = key;
-                    values = new ArrayList<String>();
+                    values = new ArrayList<>();
                     String value = matcher.group(2);
                     if (StringUtils.isNotEmpty(value))
                         values.add(value);

--- a/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/SeleneseRunnerOptions.java
@@ -152,7 +152,7 @@ public class SeleneseRunnerOptions extends Options {
 
     private int i = 0;
 
-    private final Map<Option, Integer> optionOrder = new HashMap<Option, Integer>();
+    private final Map<Option, Integer> optionOrder = new HashMap<>();
 
     /**
      * Constructor.

--- a/src/main/java/jp/vmi/selenium/selenese/highlight/HighlightStyle.java
+++ b/src/main/java/jp/vmi/selenium/selenese/highlight/HighlightStyle.java
@@ -53,7 +53,7 @@ public class HighlightStyle {
      * @param styles style for highlighting.
      */
     public HighlightStyle(String... styles) {
-        this.styles = new HashMap<String, String>();
+        this.styles = new HashMap<>();
         for (String style : styles) {
             String[] kv = style.split("\\s*:\\s*", 2);
             this.styles.put(kv[0], kv[1]);

--- a/src/main/java/jp/vmi/selenium/selenese/locator/AdditionalHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/AdditionalHandler.java
@@ -37,7 +37,7 @@ public class AdditionalHandler implements LocatorHandler {
 
     @Override
     public List<WebElement> handle(WebDriver driver, String arg) {
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         if (driver instanceof JavascriptExecutor) {
             Object element = ((JavascriptExecutor) driver).executeScript(script, arg);
             if (element instanceof WebElement)

--- a/src/main/java/jp/vmi/selenium/selenese/locator/DomHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/DomHandler.java
@@ -16,7 +16,7 @@ class DomHandler implements LocatorHandler {
 
     @Override
     public List<WebElement> handle(WebDriver driver, String arg) {
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         String script = "return (" + arg + ");";
         Object element = ((JavascriptExecutor) driver).executeScript(script);
         if (element instanceof WebElement)

--- a/src/main/java/jp/vmi/selenium/selenese/locator/LinkHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/LinkHandler.java
@@ -21,7 +21,7 @@ class LinkHandler implements LocatorHandler {
     }
 
     private List<WebElement> findByRegexp(WebDriver driver, By by, Pattern pattern) {
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         List<WebElement> as = driver.findElements(by);
         for (WebElement a : as) {
             String text;

--- a/src/main/java/jp/vmi/selenium/selenese/locator/Locator.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/Locator.java
@@ -53,7 +53,7 @@ public class Locator {
     public final String option;
 
     /** frame list. */
-    public final Deque<Integer> frameIndexList = new ArrayDeque<Integer>();
+    public final Deque<Integer> frameIndexList = new ArrayDeque<>();
 
     private static String formatLocator(String locator, String option) {
         return (option == null) ? locator : locator + " (" + option + ")";

--- a/src/main/java/jp/vmi/selenium/selenese/locator/NameHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/NameHandler.java
@@ -30,7 +30,7 @@ class NameHandler implements LocatorHandler {
         List<WebElement> result = driver.findElements(By.name(args[0]));
         if (result.isEmpty() || args.length == 1)
             return result;
-        List<WebElement> filtered = new ArrayList<WebElement>();
+        List<WebElement> filtered = new ArrayList<>();
         Matcher matcher = FILTER_RE.matcher(args[1]);
         matcher.matches();
         String indexString = matcher.group(1);

--- a/src/main/java/jp/vmi/selenium/selenese/locator/OptionIndexHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/OptionIndexHandler.java
@@ -20,7 +20,7 @@ class OptionIndexHandler implements OptionLocatorHandler {
         try {
             int index = Integer.parseInt(arg);
             List<WebElement> options = element.findElements(By.tagName("option"));
-            List<WebElement> result = new ArrayList<WebElement>();
+            List<WebElement> result = new ArrayList<>();
             if (index < options.size())
                 result.add(options.get(index));
             return result;

--- a/src/main/java/jp/vmi/selenium/selenese/locator/OptionLabelHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/OptionLabelHandler.java
@@ -18,7 +18,7 @@ class OptionLabelHandler implements OptionLocatorHandler {
     @Override
     public List<WebElement> handle(WebElement element, String arg) {
         List<WebElement> options = element.findElements(By.tagName("option"));
-        List<WebElement> result = new ArrayList<WebElement>(options.size());
+        List<WebElement> result = new ArrayList<>(options.size());
         for (WebElement option : options)
             if (SeleniumUtils.patternMatches(arg, option.getText()))
                 result.add(option);

--- a/src/main/java/jp/vmi/selenium/selenese/locator/OptionValueHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/OptionValueHandler.java
@@ -18,7 +18,7 @@ class OptionValueHandler implements OptionLocatorHandler {
     @Override
     public List<WebElement> handle(WebElement element, String arg) {
         List<WebElement> options = element.findElements(By.tagName("option"));
-        List<WebElement> result = new ArrayList<WebElement>(options.size());
+        List<WebElement> result = new ArrayList<>(options.size());
         for (WebElement option : options)
             if (SeleniumUtils.patternMatches(arg, option.getAttribute("value")))
                 result.add(option);

--- a/src/main/java/jp/vmi/selenium/selenese/locator/UnsupportedLocatorHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/UnsupportedLocatorHandler.java
@@ -15,6 +15,6 @@ abstract class UnsupportedLocatorHandler implements LocatorHandler {
     @Override
     public List<WebElement> handle(WebDriver driver, String arg) {
         log.warn("\"{}\" locator is not supported. It returns an empty list.", locatorType());
-        return new ArrayList<WebElement>();
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/locator/WebDriverElementFinder.java
+++ b/src/main/java/jp/vmi/selenium/selenese/locator/WebDriverElementFinder.java
@@ -48,10 +48,10 @@ public class WebDriverElementFinder extends ElementFinder {
         return parentLocator + Locator.OPTION_LOCATOR_SEPARATOR + optionLocator;
     }
 
-    private final Map<String, LocatorHandler> handlerMap = new HashMap<String, LocatorHandler>();
-    private final Map<String, OptionLocatorHandler> optionHandlerMap = new HashMap<String, OptionLocatorHandler>();
+    private final Map<String, LocatorHandler> handlerMap = new HashMap<>();
+    private final Map<String, OptionLocatorHandler> optionHandlerMap = new HashMap<>();
 
-    private final List<Locator> currentFrameLocators = new ArrayList<Locator>();
+    private final List<Locator> currentFrameLocators = new ArrayList<>();
 
     private WebDriver noParentFrameWebDriver = null;
 
@@ -115,7 +115,7 @@ public class WebDriverElementFinder extends ElementFinder {
     private void switchToFrame(WebDriver driver, List<Locator> plocs) {
         driver.switchTo().defaultContent();
         try {
-            List<Locator> selectedFrameLocators = new ArrayList<Locator>();
+            List<Locator> selectedFrameLocators = new ArrayList<>();
             for (Locator ploc : plocs) {
                 for (int index : ploc.frameIndexList)
                     driver.switchTo().frame(index);
@@ -207,7 +207,7 @@ public class WebDriverElementFinder extends ElementFinder {
         OptionLocatorHandler handler = optionHandlerMap.get(type);
         if (handler == null)
             throw new UnsupportedOperationException("Unknown option locator type: " + option);
-        List<WebElement> result = new ArrayList<WebElement>();
+        List<WebElement> result = new ArrayList<>();
         for (WebElement element : elements)
             result.addAll(handler.handle(element, arg));
         return result;
@@ -336,6 +336,6 @@ public class WebDriverElementFinder extends ElementFinder {
      * @return current frame locators.
      */
     public List<Locator> getCurrentFrameLocators() {
-        return new ArrayList<Locator>(currentFrameLocators);
+        return new ArrayList<>(currentFrameLocators);
     }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/log/CookieMap.java
+++ b/src/main/java/jp/vmi/selenium/selenese/log/CookieMap.java
@@ -37,7 +37,7 @@ public class CookieMap extends TreeMap<CookieKey, CookieValue> {
      * @return list of cookie string.
      */
     public List<String> allMessages(CookieFilter cookieFilter) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (CookieValue value : values())
             if (cookieFilter.isPass(value.key.name))
                 list.add(value.toString());
@@ -53,7 +53,7 @@ public class CookieMap extends TreeMap<CookieKey, CookieValue> {
      * @return list of differential cookie string.
      */
     public List<String> diffMessages(CookieFilter cookieFilter, CookieMap prev) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         for (CookieValue value : values()) {
             if (cookieFilter.isPass(value.key.name)) {
                 CookieValue prevValue = prev.get(value.key);

--- a/src/main/java/jp/vmi/selenium/selenese/log/PageInformation.java
+++ b/src/main/java/jp/vmi/selenium/selenese/log/PageInformation.java
@@ -29,7 +29,7 @@ public class PageInformation {
         if (msg != null) {
             return msg.replaceFirst("(?s)\r?\nBuild info:.*", "");
         } else {
-            List<String> msgs = new ArrayList<String>();
+            List<String> msgs = new ArrayList<>();
             msgs.add(e.toString());
             String pkgName = PageInformation.class.getPackage().getName() + ".";
             for (StackTraceElement ste : e.getStackTrace()) {

--- a/src/main/java/jp/vmi/selenium/selenese/result/CommandResultList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/CommandResultList.java
@@ -15,7 +15,7 @@ import static jp.vmi.selenium.selenese.result.Unexecuted.*;
  */
 public class CommandResultList implements List<CommandResult> {
 
-    private final List<CommandResult> list = new ArrayList<CommandResult>();
+    private final List<CommandResult> list = new ArrayList<>();
     private Result result = UNEXECUTED;
     private long endTime = System.currentTimeMillis();
     private CommandResultMap map = null;

--- a/src/main/java/jp/vmi/selenium/selenese/result/CommandResultMap.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/CommandResultMap.java
@@ -22,7 +22,7 @@ public class CommandResultMap implements Map<ICommand, List<CommandResult>> {
      * @param cresultList command result list.
      */
     public CommandResultMap(CommandResultList cresultList) {
-        map = new IdentityHashMap<ICommand, List<CommandResult>>(cresultList.size());
+        map = new IdentityHashMap<>(cresultList.size());
         putAll(cresultList);
     }
 
@@ -40,7 +40,7 @@ public class CommandResultMap implements Map<ICommand, List<CommandResult>> {
         ICommand command = ((CommandResult) cresult).getCommand();
         List<CommandResult> list = map.get(command);
         if (list == null)
-            map.put(command, list = new ArrayList<CommandResult>(1));
+            map.put(command, list = new ArrayList<>(1));
         list.add((CommandResult) cresult);
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/subcommand/GetSelected.java
+++ b/src/main/java/jp/vmi/selenium/selenese/subcommand/GetSelected.java
@@ -71,7 +71,7 @@ public class GetSelected extends AbstractSubCommand<Object> {
         if (select == null)
             return null;
         List<WebElement> options = select.findElements(By.tagName("option"));
-        List<Object> found = new ArrayList<Object>();
+        List<Object> found = new ArrayList<>();
         int i = -1;
         for (WebElement option : options) {
             i++;

--- a/src/main/java/jp/vmi/selenium/selenese/subcommand/SeleneseRunnerWindows.java
+++ b/src/main/java/jp/vmi/selenium/selenese/subcommand/SeleneseRunnerWindows.java
@@ -173,7 +173,7 @@ public class SeleneseRunnerWindows extends Windows {
   public void selectBlankWindow(WebDriver driver) {
     String current = driver.getWindowHandle();
     // Find the first window without a "name" attribute
-    List<String> handles = new ArrayList<String>(driver.getWindowHandles());
+    List<String> handles = new ArrayList<>(driver.getWindowHandles());
     for (String handle : handles) {
       // the original window will never be a _blank window, so don't even look at it
       // this is also important to skip, because the original/root window won't have

--- a/src/main/java/jp/vmi/selenium/selenese/utils/CommandDumper.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/CommandDumper.java
@@ -93,10 +93,10 @@ public class CommandDumper {
      * @param args command line parameters.
      */
     public static void main(String[] args) {
-        Map<String, String> commandInfo = new HashMap<String, String>();
+        Map<String, String> commandInfo = new HashMap<>();
         addCommandInformationFromSubCommandMap(commandInfo);
         addCommandInformationFromCommandFactory(commandInfo);
-        List<Entry<String, String>> result = new ArrayList<Entry<String, String>>(commandInfo.entrySet());
+        List<Entry<String, String>> result = new ArrayList<>(commandInfo.entrySet());
         Collections.sort(result, new Comparator<Entry<String, String>>() {
             @Override
             public int compare(Entry<String, String> e1, Entry<String, String> e2) {

--- a/src/main/java/jp/vmi/selenium/selenese/utils/EscapeUtils.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/EscapeUtils.java
@@ -20,7 +20,7 @@ public class EscapeUtils {
     public static final Pattern HTML_RE = Pattern.compile("([<>&\"'\\\\])|\r?\n|\r");
 
     /** Mapping table for HTML escape. */
-    public static final Map<String, String> HTML_ESC_MAP = new HashMap<String, String>();
+    public static final Map<String, String> HTML_ESC_MAP = new HashMap<>();
 
     static {
         HTML_ESC_MAP.put("<", "&lt;");

--- a/src/main/java/jp/vmi/selenium/selenese/utils/LogRecorder.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/LogRecorder.java
@@ -46,9 +46,9 @@ public class LogRecorder {
 
     private final PrintStream ps;
 
-    private final List<LogMessage> messages = new ArrayList<LogMessage>();
+    private final List<LogMessage> messages = new ArrayList<>();
 
-    private final List<LogMessage> errorMessages = new ArrayList<LogMessage>();
+    private final List<LogMessage> errorMessages = new ArrayList<>();
 
     /**
      * Constructor.

--- a/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/DriverOptions.java
@@ -77,7 +77,7 @@ public class DriverOptions {
     private final IdentityHashMap<DriverOptions.DriverOption, String> map = Maps.newIdentityHashMap();
     private final DesiredCapabilities caps = new DesiredCapabilities();
     private String[] cliArgs = ArrayUtils.EMPTY_STRING_ARRAY;
-    private List<File> chromeExtensions = new ArrayList<File>();
+    private List<File> chromeExtensions = new ArrayList<>();
     private final HashMap<String, String> envVars = Maps.newHashMap();
 
     /**
@@ -319,7 +319,7 @@ public class DriverOptions {
         Map<String, Object> capsMap = (Map<String, Object>) caps.asMap();
         if (!capsMap.isEmpty()) {
             result.append(sep).append("DEFINE=[\n");
-            List<Entry<String, Object>> capsList = new ArrayList<Entry<String, Object>>(capsMap.entrySet());
+            List<Entry<String, Object>> capsList = new ArrayList<>(capsMap.entrySet());
             Collections.sort(capsList, mapEntryComparator);
             for (Entry<String, Object> cap : capsList) {
                 Object value = cap.getValue();
@@ -332,7 +332,7 @@ public class DriverOptions {
         }
         if (!envVars.isEmpty()) {
             result.append(sep).append("ENV_VARS=[\n");
-            List<Entry<String, String>> envVarsList = new ArrayList<Entry<String, String>>(envVars.entrySet());
+            List<Entry<String, String>> envVarsList = new ArrayList<>(envVars.entrySet());
             Collections.sort(envVarsList, mapEntryComparator);
             for (Entry<String, String> envVar : envVarsList)
                 result.append("  ").append(envVar.getKey()).append('=').append(envVar.getValue()).append("\n");

--- a/src/test/java/jp/vmi/script/JSWrapperTest.java
+++ b/src/test/java/jp/vmi/script/JSWrapperTest.java
@@ -27,7 +27,7 @@ public class JSWrapperTest {
     @Test
     public void testMap() throws Exception {
         Object object = engine.eval("var map = {'abc': 'ABC', 'def': 'DEF', 'ghi': 'GHI'}; map");
-        JSMap<String, String> map = new JSMap<String, String>(engine, object);
+        JSMap<String, String> map = new JSMap<>(engine, object);
         assertThat(map.get("abc"), equalTo("ABC"));
         assertThat(map.keySet(), equalTo((Set<String>) Sets.newHashSet("abc", "def", "ghi")));
         assertThat(map.size(), equalTo(3));
@@ -36,7 +36,7 @@ public class JSWrapperTest {
     @Test
     public void testList() throws Exception {
         Object object = engine.eval("var list = ['abc', 'def', 'ghi']; list");
-        JSList<String> list = new JSList.JSNativeList<String>(engine, object);
+        JSList<String> list = new JSList.JSNativeList<>(engine, object);
         assertThat(list.get(1), equalTo("def"));
         assertThat(list.size(), equalTo(3));
     }

--- a/src/test/java/jp/vmi/selenium/rollup/RollupTest.java
+++ b/src/test/java/jp/vmi/selenium/rollup/RollupTest.java
@@ -33,7 +33,7 @@ public class RollupTest extends TestBase {
         rollupRules.load(getClass().getResourceAsStream("/rollup/user-extention-rollup.js"));
         IRollupRule rule = rollupRules.get("do_login");
         assertThat(rule, is(instanceOf(RollupRule.class)));
-        Map<String, String> rollupArgs = new HashMap<String, String>();
+        Map<String, String> rollupArgs = new HashMap<>();
         rollupArgs.put("username", "USERNAME");
         rollupArgs.put("password", "PASSWORD");
         CommandList commandList = rule.getExpandedCommands(runner, rollupArgs);

--- a/src/test/java/jp/vmi/selenium/selenese/command/CommandSequenceTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/command/CommandSequenceTest.java
@@ -49,8 +49,8 @@ public class CommandSequenceTest {
     private static final char E = 'e';
 
     private static List<ICommand> build(char... cmds) {
-        List<ICommand> result = new ArrayList<ICommand>();
-        Deque<StartLoop> startLoopStack = new ArrayDeque<StartLoop>();
+        List<ICommand> result = new ArrayList<>();
+        Deque<StartLoop> startLoopStack = new ArrayDeque<>();
         startLoopStack.addFirst(StartLoop.NO_START_LOOP);
         for (char cmd : cmds) {
             switch (cmd) {

--- a/src/test/java/jp/vmi/selenium/selenese/locator/LinkHandlerTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/locator/LinkHandlerTest.java
@@ -129,7 +129,7 @@ public class LinkHandlerTest extends TestBase {
             { "assertElementNotPresent", "exact:assertion test", Failure.class }
 
         };
-        ArrayList<Object[]> data = new ArrayList<Object[]>();
+        ArrayList<Object[]> data = new ArrayList<>();
         for (Object[] factory : factories)
             for (Object[] args : argss)
                 data.add(ArrayUtils.addAll(factory, args));

--- a/src/test/java/jp/vmi/selenium/testutils/TestCaseTestBase.java
+++ b/src/test/java/jp/vmi/selenium/testutils/TestCaseTestBase.java
@@ -48,7 +48,7 @@ public abstract class TestCaseTestBase extends TestBase {
     public void initialize() {
         initDriver();
 
-        testSuites = new ArrayList<TestSuite>();
+        testSuites = new ArrayList<>();
         runner = new Runner() {
             @Override
             public Result execute(Selenese testSuite) {
@@ -89,7 +89,7 @@ public abstract class TestCaseTestBase extends TestBase {
     }
 
     protected List<String> getSystemOut(Filter filter) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         Pattern re = Pattern.compile("<system-out>(.*?)</system-out>", Pattern.DOTALL);
         Matcher m = re.matcher(xmlResult);
         if (!m.find())
@@ -104,7 +104,7 @@ public abstract class TestCaseTestBase extends TestBase {
     }
 
     protected List<String> listFilter(Filter filter, List<String> src) {
-        List<String> dst = new ArrayList<String>();
+        List<String> dst = new ArrayList<>();
         for (String line : src) {
             String filtered = filter.filter(line);
             if (filtered != null)

--- a/src/test/java/jp/vmi/selenium/testutils/TestUtils.java
+++ b/src/test/java/jp/vmi/selenium/testutils/TestUtils.java
@@ -49,7 +49,7 @@ public final class TestUtils {
      */
     @SafeVarargs
     public static <T> List<Object[]> toParamList(T... params) {
-        List<Object[]> list = new ArrayList<Object[]>();
+        List<Object[]> list = new ArrayList<>();
         for (T param : params)
             list.add(new Object[] { param });
         return list;

--- a/src/test/java/jp/vmi/selenium/testutils/WebServer.java
+++ b/src/test/java/jp/vmi/selenium/testutils/WebServer.java
@@ -48,7 +48,7 @@ public class WebServer {
             String html = IOUtils.toString(is, CharsetUtil.UTF_8)
                 .replaceFirst("(?s)<script[^>]*>.*?</script>", "") // remove script tag.
                 .replaceFirst("<body.*?>", "<body>"); // remove "onload" handler.
-            List<String> keys = new ArrayList<String>(request.queryParamKeys());
+            List<String> keys = new ArrayList<>(request.queryParamKeys());
             Collections.sort(keys);
             for (String key : keys) {
                 String value = request.queryParam(key);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.