### PR TITLE
Added include command

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
@@ -72,6 +72,9 @@ public class CommandFactory implements ICommandFactory {
 
         // commands for comment
         addConstructor(Comment.class);
+
+        // commands for include
+        addConstructor(Include.class);
     }
 
     private static final String AND_WAIT = "AndWait";

--- a/src/main/java/jp/vmi/selenium/selenese/command/Include.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Include.java
@@ -1,0 +1,45 @@
+package jp.vmi.selenium.selenese.command;
+
+import org.apache.commons.io.FilenameUtils;
+
+import jp.vmi.selenium.selenese.Parser;
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.TestCase;
+import jp.vmi.selenium.selenese.Selenese;
+import jp.vmi.selenium.selenese.result.Result;
+import jp.vmi.selenium.selenese.result.Error;
+import jp.vmi.selenium.selenese.result.Success;
+
+import static jp.vmi.selenium.selenese.command.ArgumentType.*;
+import static jp.vmi.selenium.selenese.result.Success.*;
+
+/**
+ * Command "include".
+ */
+public class Include extends AbstractCommand {
+
+    private static final int ARG_FILENAME = 0;
+
+    Include(int index, String name, String... args) {
+        super(index, name, args, VALUE);
+    }
+
+    @Override
+    protected Result executeImpl(Context context, String... curArgs) {
+
+        String filename = context.getVarsMap().replaceVars(curArgs[ARG_FILENAME]);
+        String path = FilenameUtils.getFullPathNoEndSeparator(context.getCurrentTestCase().getFilename());
+
+        if (FilenameUtils.getPrefixLength(filename) == 0)
+            filename = FilenameUtils.concat(path, filename);
+
+        Selenese child = Parser.parse(filename, context.getCommandFactory());
+        if (child instanceof TestCase) {
+            CommandList commandList = ((TestCase)child).getCommandList();
+            Result result = commandList.execute(context);
+            return result == SUCCESS ? new Success("Success: " + filename) : result;
+        }
+
+        return new Error("TestCase expected: " + filename);
+    }
+}

--- a/src/test/java/jp/vmi/selenium/selenese/IncludeCommandTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/IncludeCommandTest.java
@@ -1,0 +1,27 @@
+package jp.vmi.selenium.selenese;
+
+import org.junit.Test;
+
+import jp.vmi.selenium.testutils.TestBase;
+import jp.vmi.selenium.testutils.TestUtils;
+import jp.vmi.selenium.webdriver.DriverOptions;
+import jp.vmi.selenium.webdriver.WebDriverManager;
+
+/**
+ * Test for {@link TestSuite}.
+ */
+public class IncludeCommandTest extends TestBase {
+
+    /**
+     * Test of "testcase_include.html".
+     */
+    @Test
+    public void testTestSuite() {
+        String script = TestUtils.getScriptFile("testcase_include");
+        setWebDriverFactory(WebDriverManager.HTMLUNIT, new DriverOptions());
+        Runner runner = new Runner();
+        runner.setDriver(manager.get());
+        runner.setOverridingBaseURL(wsr.getBaseURL());
+        runner.run(script);
+    }
+}

--- a/src/test/resources/selenese/includes/form-submit.html
+++ b/src/test/resources/selenese/includes/form-submit.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link rel="selenium.base" href="http://localhost/" />
+    <title>Include test - form submit</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+    <thead>
+    <tr><td rowspan="1" colspan="3">Include test - form submit</td></tr>
+    </thead><tbody>
+    <tr>
+        <td>type</td>
+        <td>name=text</td>
+        <td>selenium</td>
+    </tr>
+    <tr>
+        <td>submitAndWait</td>
+        <td>name=form</td>
+        <td></td>
+    </tr>
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/includes/form-verify.html
+++ b/src/test/resources/selenese/includes/form-verify.html
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link rel="selenium.base" href="http://localhost/" />
+    <title>Include test - form verify</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+    <thead>
+    <tr><td rowspan="1" colspan="3">Include test - form verify</td></tr>
+    </thead><tbody>
+    <tr>
+        <td>verifyText</td>
+        <td>id=text</td>
+        <td>selenium</td>
+    </tr>
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/testcase_include.html
+++ b/src/test/resources/selenese/testcase_include.html
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link rel="selenium.base" href="http://localhost/" />
+    <title>Test Case Include Command</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+    <thead>
+    <tr><td rowspan="1" colspan="3">Test Case Include Command</td></tr>
+    </thead><tbody>
+    <tr>
+        <td>open</td>
+        <td>/form.html</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>store</td>
+        <td>submit</td>
+        <td>variable_test</td>
+    </tr>
+    <tr>
+        <td>include</td>
+        <td>includes/form-${variable_test}.html</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>include</td>
+        <td>includes/form-verify.html</td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
This feature provides the possibility to include selenese-scripts. So you can re-use them in a better way. It's also possible to use variables in filenames.

Example:
`<tr>
        <td>include</td>
        <td>includes/form-${variable_test}.html</td>
        <td></td>
    </tr>
    <tr>
        <td>include</td>
        <td>includes/form-verify.html</td>
        <td></td>
    </tr>
`