### PR TITLE
Add "--max-time" option,  Limit the time the whole operation is allowed to take.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
             <pushChanges>false</pushChanges>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>aspectj-maven-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -371,6 +376,32 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.2</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <version>1.8</version>
+        <configuration>
+          <showWeaveInfo>true</showWeaveInfo>
+          <verbose>true</verbose>
+          <complianceLevel>${target.version}</complianceLevel>
+          <source>${source.version}</source>
+          <target>${target.version}</target>
+          <weaveDependencies>
+            <weaveDependency>
+              <groupId>org.seleniumhq.selenium</groupId>
+              <artifactId>selenium-remote-driver</artifactId>
+            </weaveDependency>
+          </weaveDependencies>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencyManagement>
@@ -450,11 +481,6 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
             <artifactId>selenium-support</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-	<groupId>org.apache.httpcomponents</groupId>
-	<artifactId>httpclient</artifactId>
-	<version>${httpclient.version}</version>
       </dependency>
       <dependency>
 	<groupId>org.apache.httpcomponents</groupId>
@@ -544,6 +570,16 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
       <version>3.2.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.2</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -591,6 +627,11 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>htmlunit-driver</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+      <version>1.8.7</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/src/main/aspect/org/openqa/selenium/remote/internal/CreateHttpAsyncClient.java
+++ b/src/main/aspect/org/openqa/selenium/remote/internal/CreateHttpAsyncClient.java
@@ -1,0 +1,84 @@
+package org.openqa.selenium.remote.internal;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.conn.DefaultSchemePortResolver;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.openqa.selenium.WebDriverException;
+
+import java.net.ProxySelector;
+import java.net.URL;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Override {@link org.openqa.selenium.remote.internal.ApacheHttpClient.Factory#createClient(URL)} to return {@link ApacheHttpAsyncClient}
+ */
+@Aspect
+public class CreateHttpAsyncClient {
+
+    //  {@link org.openqa.selenium.remote.internal.HttpClientFactory}'s defaults
+    private final int TIMEOUT_THREE_HOURS = (int) SECONDS.toMillis(60 * 60 * 3);
+    private final int TIMEOUT_TWO_MINUTES = (int) SECONDS.toMillis(60 * 2);
+
+    @Around("execution(public org.openqa.selenium.remote.http.HttpClient org.openqa.selenium.remote.internal.ApacheHttpClient.Factory.createClient(java.net.URL))")
+    public Object createClient(ProceedingJoinPoint p) throws IOReactorException {
+        int connectionTimeout = TIMEOUT_TWO_MINUTES;
+        int socketTimeout = TIMEOUT_THREE_HOURS;
+
+        URL url = (URL) p.getArgs()[0];
+        checkNotNull(url, "null URL");
+
+        if (connectionTimeout <= 0) {
+            throw new IllegalArgumentException("connection timeout must be > 0");
+        }
+        if (socketTimeout <= 0) {
+            throw new IllegalArgumentException("socket timeout must be > 0");
+        }
+
+        // same as HttpClientFactory#createRequestConfig(int, int)
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setStaleConnectionCheckEnabled(true)
+                .setConnectTimeout(connectionTimeout)
+                .setSocketTimeout(socketTimeout)
+                .build();
+        // same as HttpClientFactory#createRoutePlanner()
+        HttpRoutePlanner routePlanner = new SystemDefaultRoutePlanner(
+                new DefaultSchemePortResolver(), ProxySelector.getDefault());
+
+        ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+        PoolingNHttpClientConnectionManager cm = new PoolingNHttpClientConnectionManager(ioReactor);
+        // these values are obtained from HttpClientFactory#getClientConnectionManager()
+        cm.setMaxTotal(2000);
+        cm.setDefaultMaxPerRoute(2000);
+
+        HttpAsyncClientBuilder builder = HttpAsyncClientBuilder.create()
+                .setConnectionManager(cm)
+                .setDefaultRequestConfig(requestConfig)
+                .setRoutePlanner(routePlanner);
+
+        if (url.getUserInfo() != null) {
+            UsernamePasswordCredentials credentials =
+                    new UsernamePasswordCredentials(url.getUserInfo());
+            CredentialsProvider provider = new BasicCredentialsProvider();
+            provider.setCredentials(AuthScope.ANY, credentials);
+            builder.setDefaultCredentialsProvider(provider);
+        }
+
+        return new ApacheHttpAsyncClient(builder.build(), url);
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -102,6 +102,12 @@ public class Main {
      * @param filenames filenames of test-suites/test-cases.
      */
     public void setupRunner(Runner runner, IConfig config, String... filenames) {
+        if (config.getMaxTime() != null) {
+            long maxTime = NumberUtils.toLong(config.getMaxTime(), 0);
+            if (maxTime <= 0)
+                throw new IllegalArgumentException("Invalid max time value. (" + config.getMaxTime() + ")");
+            runner.setupMaxTimeTimer(maxTime * 1000);
+        }
         String driverName = config.getDriver();
         DriverOptions driverOptions = new DriverOptions(config);
         if (driverName == null) {

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -69,7 +69,8 @@ public class DefaultConfig implements IConfig {
         statusListItem(WARNING),
         statusListItem(FAILURE),
         statusListItem(ERROR),
-        statusListItem(UNEXECUTED)
+        statusListItem(UNEXECUTED),
+        statusListItem(MAX_TIME_EXCEEDED)
     };
 
     private final CmdLineParser parser;
@@ -189,6 +190,9 @@ public class DefaultConfig implements IConfig {
 
     @Option(name = "--strict-exit-code", usage = "return strict exit code, reflected by selenese command results at end. (See Note *4)")
     private Boolean strictExitCode;
+
+    @Option(name = "--max-time", metaVar = "<max-time>",usage = "Maximum time in seconds that you allow the entire operation to take.")
+    private String maxTime;
 
     @Option(name = "--help", aliases = "-h", usage = "show this message.")
     private Boolean help;
@@ -537,6 +541,15 @@ public class DefaultConfig implements IConfig {
 
     public void setStrictExitCode(boolean strictExitCode) {
         this.strictExitCode = strictExitCode;
+    }
+
+    @Override
+    public String getMaxTime() {
+        return maxTime != null ? maxTime : (parentOptions != null ? parentOptions.getMaxTime() : null);
+    }
+
+    public void setMaxTime(String maxTime) {
+        this.maxTime = maxTime;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -44,6 +44,7 @@ public interface IConfig {
     public static final String COMMAND_FACTORY = "command-factory";
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
+    public static final String MAX_TIME = "max-time";
     public static final String HELP = "help";
 
     /**
@@ -199,6 +200,8 @@ public interface IConfig {
     boolean isNoExit();
 
     boolean isStrictExitCode();
+
+    String getMaxTime();
 
     boolean isHelp();
 }

--- a/src/main/java/jp/vmi/selenium/selenese/inject/BindModule.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/BindModule.java
@@ -63,9 +63,10 @@ public class BindModule extends AbstractModule {
      */
     protected AbstractDoCommandInterceptor[] getDoCommandInterceptors() {
         return new AbstractDoCommandInterceptor[] {
-            new CommandLogInterceptor(), /* 1st */
-            new HighlightInterceptor(), /* 2nd */
-            new ScreenshotInterceptor() /* 3rd */
+            new MaxTimeInterruptInterceptor(), /* 1st */
+            new CommandLogInterceptor(), /* 2nd */
+            new HighlightInterceptor(), /* 3rd */
+            new ScreenshotInterceptor() /* 4th */
         };
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/inject/MaxTimeInterruptInterceptor.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/MaxTimeInterruptInterceptor.java
@@ -1,0 +1,40 @@
+package jp.vmi.selenium.selenese.inject;
+
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.command.ICommand;
+import jp.vmi.selenium.selenese.result.MaxTimeExceeded;
+import jp.vmi.selenium.selenese.result.Result;
+import org.aopalliance.intercept.MethodInvocation;
+
+import static java.lang.Thread.currentThread;
+import static java.lang.Thread.interrupted;
+import static jp.vmi.selenium.selenese.Runner.MaxTimeTimer.isInterruptedByMaxTimeTimer;
+
+/**
+ * Interceptor class handles interruption made by {@link jp.vmi.selenium.selenese.Runner.MaxTimeTimer}.
+ */
+public class MaxTimeInterruptInterceptor extends AbstractDoCommandInterceptor {
+
+    @Override
+    protected Result invoke(MethodInvocation invocation, Context context, ICommand command, String[] curArgs) throws Throwable {
+        Result result = null;
+        if (isInterruptedByMaxTimeTimer(currentThread())) {
+            interrupted(); // clear interrupted status only when the thread is interrupted by MaxTimeTimer
+            return new MaxTimeExceeded();
+        }
+        try {
+            result = (Result) invocation.proceed();
+        } catch (Throwable t) {
+            if (isInterruptedByMaxTimeTimer(currentThread())) {
+                interrupted();;
+                return new MaxTimeExceeded((Exception) t);
+            }
+            throw t;
+        }
+        if (isInterruptedByMaxTimeTimer(currentThread())) {
+            interrupted();
+            return new MaxTimeExceeded();
+        }
+        return result;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/result/MaxTimeExceeded.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/MaxTimeExceeded.java
@@ -1,0 +1,38 @@
+package jp.vmi.selenium.selenese.result;
+
+/**
+ * Result of Maximum execution time exceeded.
+ * @since 2.9.1
+ */
+public class MaxTimeExceeded extends Result {
+
+    /**
+     * Default constructor.
+     */
+    public MaxTimeExceeded() {
+        super("Maximum execution time exceeded");
+    }
+    /**
+     * Constructor.
+     *
+     * @param message the detail message.
+     */
+    public MaxTimeExceeded(String message) {
+        super("Maximum execution time exceeded", message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause the cause.
+     */
+    public MaxTimeExceeded(Exception cause) {
+        super("Maximum execution time exceeded", cause);
+    }
+
+    @Override
+    public Level getLevel() {
+        return Level.MAX_TIME_EXCEEDED;
+    }
+}
+

--- a/src/main/java/jp/vmi/selenium/selenese/result/Result.java
+++ b/src/main/java/jp/vmi/selenium/selenese/result/Result.java
@@ -16,7 +16,8 @@ public abstract class Result implements Comparable<Result> {
         SUCCESS(0, 0, 0),
         WARNING(1, 0, 2),
         FAILURE(2, 3, 3),
-        ERROR(3, 3, 4);
+        ERROR(3, 3, 4),
+        MAX_TIME_EXCEEDED(4, 3, 6);
 
         public final int value;
         public final int exitCode;

--- a/src/main/java/org/openqa/selenium/remote/internal/ApacheHttpAsyncClient.java
+++ b/src/main/java/org/openqa/selenium/remote/internal/ApacheHttpAsyncClient.java
@@ -1,0 +1,210 @@
+// This is the modified version of the ApacheHttpClient in selenium-remote-driver.
+//
+// The following copyright is copied from original.
+// ---
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote.internal;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.http.HttpMethod;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+
+public class ApacheHttpAsyncClient implements org.openqa.selenium.remote.http.HttpClient {
+
+    private static final int MAX_REDIRECTS = 10;
+
+    private final URL url;
+    private final HttpHost targetHost;
+    private final CloseableHttpAsyncClient client;
+
+    public ApacheHttpAsyncClient(CloseableHttpAsyncClient client, URL url) {
+        this.client = checkNotNull(client, "null HttpClient");
+        this.url = checkNotNull(url, "null URL");
+
+        // Some machines claim "localhost.localdomain" is the same as "localhost".
+        // This assumption is not always true.
+        String host = url.getHost().replace(".localdomain", "");
+        this.targetHost = new HttpHost(host, url.getPort(), url.getProtocol());
+    }
+
+    @Override
+    public HttpResponse execute(HttpRequest request, boolean followRedirects) throws IOException {
+        HttpContext context = createContext();
+
+        String requestUrl = url.toExternalForm().replaceAll("/$", "") + request.getUri();
+        HttpUriRequest httpMethod = createHttpUriRequest(request.getMethod(), requestUrl);
+        for (String name : request.getHeaderNames()) {
+            // Skip content length as it is implicitly set when the message entity is set below.
+            if (!"Content-Length".equalsIgnoreCase(name)) {
+                for (String value : request.getHeaders(name)) {
+                    httpMethod.addHeader(name, value);
+                }
+            }
+        }
+
+        if (httpMethod instanceof HttpPost) {
+            ((HttpPost) httpMethod).setEntity(new ByteArrayEntity(request.getContent()));
+        }
+        client.start(); // start if needed
+        Future<org.apache.http.HttpResponse> future = client.execute(targetHost, httpMethod, context, null);
+        try {
+            org.apache.http.HttpResponse response = future.get();
+
+            if (followRedirects) {
+                response = followRedirects(client, context, response, /* redirect count */0);
+            }
+            return createResponse(response, context);
+        } catch (InterruptedException|ExecutionException e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    /** Same implementation as {@link ApacheHttpClient#createResponse(org.apache.http.HttpResponse, HttpContext)} */
+    private HttpResponse createResponse(
+            org.apache.http.HttpResponse response, HttpContext context) throws IOException {
+        HttpResponse internalResponse = new HttpResponse();
+
+        internalResponse.setStatus(response.getStatusLine().getStatusCode());
+        for (Header header : response.getAllHeaders()) {
+            for (HeaderElement headerElement : header.getElements()) {
+                internalResponse.addHeader(header.getName(), headerElement.getValue());
+            }
+        }
+
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            try {
+                internalResponse.setContent(EntityUtils.toByteArray(entity));
+            } finally {
+                EntityUtils.consume(entity);
+            }
+        }
+
+        Object host = context.getAttribute(HTTP_TARGET_HOST);
+        if (host instanceof HttpHost) {
+            internalResponse.setTargetHost(((HttpHost) host).toURI());
+        }
+
+        return internalResponse;
+    }
+
+    /** Same implementation as {@link ApacheHttpClient#createContext()} */
+    protected HttpContext createContext() {
+        return new BasicHttpContext();
+    }
+
+    /** Same implementation as {@link ApacheHttpClient#createHttpUriRequest(HttpMethod, String)} */
+    private static HttpUriRequest createHttpUriRequest(HttpMethod method, String url) {
+        switch (method) {
+            case DELETE:
+                return new HttpDelete(url);
+            case GET:
+                return new HttpGet(url);
+            case POST:
+                return new HttpPost(url);
+        }
+        throw new AssertionError("Unsupported method: " + method);
+    }
+
+    private org.apache.http.HttpResponse followRedirects(
+            CloseableHttpAsyncClient client,
+            HttpContext context,
+            org.apache.http.HttpResponse response, int redirectCount) {
+        if (!isRedirect(response)) {
+            return response;
+        }
+
+        try {
+            // Make sure that the previous connection is freed.
+            HttpEntity httpEntity = response.getEntity();
+            if (httpEntity != null) {
+                EntityUtils.consume(httpEntity);
+            }
+        } catch (IOException e) {
+            throw new WebDriverException(e);
+        }
+
+        if (redirectCount > MAX_REDIRECTS) {
+            throw new WebDriverException("Maximum number of redirects exceeded. Aborting");
+        }
+
+        String location = response.getFirstHeader("location").getValue();
+        URI uri;
+        try {
+            uri = buildUri(context, location);
+        } catch (URISyntaxException e) {
+            throw new WebDriverException(e);
+        }
+        HttpGet get = new HttpGet(uri);
+        get.setHeader("Accept", "application/json; charset=utf-8");
+
+        Future<org.apache.http.HttpResponse> future = client.execute(targetHost, get, context, null);
+        try {
+            org.apache.http.HttpResponse newResponse = future.get();
+            return followRedirects(client, context, newResponse, redirectCount + 1);
+        } catch (InterruptedException|ExecutionException e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private URI buildUri(HttpContext context, String location) throws URISyntaxException {
+        URI uri;
+        uri = new URI(location);
+        if (!uri.isAbsolute()) {
+            HttpHost host = (HttpHost) context.getAttribute(HTTP_TARGET_HOST);
+            uri = new URI(host.toURI() + location);
+        }
+        return uri;
+    }
+
+    private boolean isRedirect(org.apache.http.HttpResponse response) {
+        int code = response.getStatusLine().getStatusCode();
+
+        return (code == 301 || code == 302 || code == 303 || code == 307)
+                && response.containsHeader("location");
+    }
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/src/test/java/jp/vmi/selenium/selenese/MaxTimeTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/MaxTimeTest.java
@@ -1,0 +1,84 @@
+package jp.vmi.selenium.selenese;
+
+import jp.vmi.selenium.selenese.result.*;
+import jp.vmi.selenium.testutils.TestCaseTestBase;
+import jp.vmi.selenium.webdriver.DriverOptions;
+import jp.vmi.selenium.webdriver.WebDriverManager;
+import org.apache.commons.lang3.time.StopWatch;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Driver independent test.
+ */
+@SuppressWarnings("javadoc")
+public class MaxTimeTest extends TestCaseTestBase {
+
+    private static final Logger log = LoggerFactory.getLogger(MaxTimeTest.class);
+
+    @Override
+    protected void initDriver() {
+        setWebDriverFactory(WebDriverManager.HTMLUNIT, new DriverOptions());
+        driver = manager.get();
+    }
+
+    protected void execute(String scriptName, long maxtime) {
+        StopWatch sw = new StopWatch();
+        runner.setupMaxTimeTimer(maxtime);
+        sw.start();
+        execute(scriptName);
+        sw.stop();
+        assertThat(sw.getTime(), is(lessThanOrEqualTo(maxtime + 1000)));
+    }
+
+    private CommandResult getLastCommandResult() {
+        CommandResultList list = runner.getCurrentTestCase().getResultList();
+        return list.get(list.size() - 1);
+    }
+
+    @Test
+    public void flowControl() throws IllegalArgumentException {
+        execute("maxTimeFlowControl", 1000);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), anyOf(is("while"),is("endWhile")));
+    }
+
+    @Test
+    public void verifyNotText() throws IllegalArgumentException {
+        execute("maxTimeVerifyNotText", 1500);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), is("verifyNotText"));
+    }
+
+    @Test
+    public void pauseCommand() throws IllegalArgumentException {
+        execute("pause", 2000);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), is("pause"));
+    }
+
+    @Test
+    public void setSpeed() throws IllegalArgumentException {
+        execute("maxTimeSetSpeed", 2000);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), is("setSpeed"));
+    }
+
+    @Test
+    public void waitForCondition() {
+        execute("maxTimeWaitForCondition", 5000);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), is("waitForCondition"));
+    }
+
+    @Test
+    public void clickAndWait() {
+        execute("maxTimeClickAndWait", 5000);
+        assertThat(result, is(instanceOf(MaxTimeExceeded.class)));
+        assertThat(getLastCommandResult().getCommand().getName(), is("clickAndWait"));
+    }
+}

--- a/src/test/resources/selenese/maxTimeClickAndWait.html
+++ b/src/test/resources/selenese/maxTimeClickAndWait.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>Max time test (clickAndWait)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">max-time test (clickAndWait)</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/wait-page.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>id=link5</td>
+	<td></td>
+</tr>
+
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/maxTimeFlowControl.html
+++ b/src/test/resources/selenese/maxTimeFlowControl.html
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>max-time test (flow control)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">max-time test (flow control)</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/form.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>runScript</td>
+	<td>setTimeout("stopLoop=true", 2000)</td>
+	<td></td>
+</tr>
+<tr>
+	<td>while</td>
+	<td>typeof stopLoop == "undefined"</td>
+	<td></td>
+</tr>
+<tr>
+	<td>endWhile</td>
+	<td></td>
+	<td></td>
+</tr>
+
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/maxTimeSetSpeed.html
+++ b/src/test/resources/selenese/maxTimeSetSpeed.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>max-time test (setSpeed)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">max-time test (setSpeed)</td></tr>
+</thead><tbody>
+<tr>
+	<td>setSpeed</td>
+	<td>5000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>setSpeed</td>
+	<td>5000</td>
+	<td></td>
+</tr>
+
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/maxTimeVerifyNotText.html
+++ b/src/test/resources/selenese/maxTimeVerifyNotText.html
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>max-time test (verifyNotText)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">max-time test (verifyNotText)</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/form.html</td>
+	<td></td>
+</tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+<tr><td>verifyNotText</td><td>//h1</td><td>verifyNotText</td></tr>
+</tbody></table>
+</body>
+</html>

--- a/src/test/resources/selenese/maxTimeWaitForCondition.html
+++ b/src/test/resources/selenese/maxTimeWaitForCondition.html
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>max-time test (waitForCondition)</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">max-time test (waitForCondition)</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/wait-condition.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=timeout</td>
+	<td>10</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=start</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForCondition</td>
+	<td>selenium.browserbot.getDocument().getElementById('message').textContent === 'End'</td>
+	<td>12000</td>
+</tr>
+
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
This pull request add "--max-time" option, limit the time for selenese-runner's entire operation.

To save HTML/XML result, this PR doesn't shutdown operation immediately, only interrupts current operation and makes result of current command failure when the time specified by "--max-time" is reached.

This PR also replace use of commons httpcomponents' httpclient in selenium-remote-driver with httpasyncclient so that we can interrupt operation immediately.

Since httpclient do blocking read, we couldn't interrupt the operation especially waiting data from server socket.
It becomes a problem when communicate with quite slow response web server, could not interrupt operation several seconds or more.