### PR TITLE
Pull request Newfeat/interactive for Issue #210

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Usage
      --remote-browser <browser>              : Desired remote browser (Remote only)
      --remote-version <browser-version>      : Desired remote browser version (Remote only)
      --highlight (-H)                        : highlight locator always.
+     --interactive (-i)                      : interactive mode.
      --screenshot-dir (-s) <dir>             : override captureEntirePageScreenshot directory.
      --screenshot-all (-S) <dir>             : take screenshot at all commands to specified directory.
      --screenshot-on-fail <dir>              : take screenshot on fail commands to specified directory.

--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -205,4 +205,12 @@ public interface Context extends WrapsDriver {
      * @param cookieFilter cookie filter.
      */
     void setCookieFilter(CookieFilter cookieFilter);
+
+    /**
+     * Get interactive
+     *
+     * @return interactive.
+     */
+    boolean isInteractive();
+
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -140,6 +140,8 @@ public class Main {
         runner.setWebDriverPreparator(manager);
         if (config.isHighlight())
             runner.setHighlight(true);
+        if (config.isInteractive())
+            runner.setInteractive(true);
         if (config.getScreenshotDir() != null)
             runner.setScreenshotDir(config.getScreenshotDir());
         if (config.getScreenshotAll() != null)

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -151,4 +151,9 @@ public class NullContext implements Context {
     @Override
     public void setCookieFilter(CookieFilter cookieFilter) {
     }
+
+    @Override
+    public boolean isInteractive() {
+        return false;
+    }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -73,6 +73,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private String screenshotOnFailDir = null;
     private boolean isIgnoredScreenshotCommand = false;
     private boolean isHighlight = false;
+    private boolean isInteractive = false;
     private int timeout = 30 * 1000; /* ms */
     private long initialSpeed = 0; /* ms */
     private long speed = 0; /* ms */
@@ -416,6 +417,21 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     public void setHighlight(boolean isHighlight) {
         this.isHighlight = isHighlight;
         log.info("Highlight mode: {}", isHighlight ? "enabled" : "disabled");
+    }
+
+    @Override
+    public boolean isInteractive() {
+        return isInteractive;
+    }
+
+    /**
+     * Set interactive.
+     *
+     * @param isInteractive true if Runner executes test step-by-step upon user key stroke.
+     */
+    public void setInteractive(boolean isInteractive) {
+        this.isInteractive = isInteractive;
+        log.info("Interactive mode: {}", isInteractive ? "enabled" : "disabled");
     }
 
     private void setDriverTimeout() {

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -94,6 +94,10 @@ public class CommandList extends ArrayList<ICommand> {
     @DoCommand
     protected Result doCommand(Context context, ICommand command, String... curArgs) {
         try {
+            if (context.isInteractive()) {
+                System.out.println(">>> Press any key to continue <<<");
+                System.in.read();
+            }
             return command.execute(context, curArgs);
         } catch (SeleneseCommandErrorException e) {
             return e.getError();

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -95,7 +95,7 @@ public class CommandList extends ArrayList<ICommand> {
     protected Result doCommand(Context context, ICommand command, String... curArgs) {
         try {
             if (context.isInteractive()) {
-                System.out.println(">>> Press any key to continue <<<");
+                System.out.println(">>> Press ENTER to continue <<<");
                 System.in.read();
             }
             return command.execute(context, curArgs);

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -128,6 +128,9 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--highlight", aliases = "-H", usage = "highlight locator always.")
     private Boolean highlight;
 
+    @Option(name = "--interactive", aliases = "-i", usage = "interactive mode.")
+    private Boolean interactive;
+
     @Option(name = "--screenshot-dir", aliases = "-s", metaVar = "<dir>", usage = "override captureEntirePageScreenshot directory.")
     private String screenshotDir;
 
@@ -352,6 +355,15 @@ public class DefaultConfig implements IConfig {
 
     public void setHighlight(boolean highlight) {
         this.highlight = highlight;
+    }
+
+    @Override
+    public boolean isInteractive() {
+        return interactive != null ? interactive : (parentOptions != null ? parentOptions.isInteractive() : false);
+    }
+
+    public void setInteractive(boolean interactive) {
+        this.interactive = interactive;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -23,6 +23,7 @@ public interface IConfig {
     public static final String REMOTE_BROWSER = "remote-browser";
     public static final String REMOTE_VERSION = "remote-version";
     public static final String HIGHLIGHT = "highlight";
+    public static final String INTERACTIVE = "interactive";
     public static final String SCREENSHOT_DIR = "screenshot-dir";
     public static final String SCREENSHOT_ALL = "screenshot-all";
     public static final String SCREENSHOT_ON_FAIL = "screenshot-on-fail";
@@ -158,6 +159,8 @@ public interface IConfig {
     String getRemoteVersion();
 
     boolean isHighlight();
+
+    boolean isInteractive();
 
     String getScreenshotDir();
 


### PR DESCRIPTION
This adds interactive mode feature (See Issue #210 ) . By default is disabled and can be enabled with `-i` or `--interactive`.

The interactive mode allows to execute Selenese test cases in a step-by-step fashion. Each step is executed by pressing enter in the terminal where selenese-runner has been run. 