### PR TITLE
treat CDATA sections as character content.

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/Parser.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Parser.java
@@ -77,6 +77,7 @@ public abstract class Parser {
             dp.setEntityResolver(null);
             dp.setFeature("http://xml.org/sax/features/namespaces", false);
             dp.setFeature(XERCES_FEATURE_PREFIX + INCLUDE_COMMENTS_FEATURE, true);
+            dp.setFeature("http://cyberneko.org/html/features/scanner/cdata-sections", true);
             dp.parse(new InputSource(is));
             Document document = dp.getDocument();
             Node seleniumBase = XPathAPI.selectSingleNode(document, "/HTML/HEAD/LINK[@rel='selenium.base']/@href");


### PR DESCRIPTION
Currently CDATA sections are treated as comment, since DOMParser's `cdata-secions` feature is disabled (by default, see https://nekohtml.sourceforge.net/settings.html#cdata-sections)
I think CDATA sections is really useful for e.g. writing raw JavaScript code in test case files.

This PR simply enable DOMParser's `cdata-sections` feature so that we can use CDATA sections in test case files.