### PR TITLE
Add --no-proxy support for chromedriver

### DIFF
--- a/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/ChromeDriverFactory.java
@@ -44,6 +44,8 @@ public class ChromeDriverFactory extends WebDriverFactory {
         ChromeOptions options = new ChromeOptions();
         if (driverOptions.has(PROXY))
             options.addArguments("--proxy-server=http://" + driverOptions.get(PROXY));
+        if (driverOptions.has(NO_PROXY))
+            options.addArguments("--proxy-bypass-list=" + driverOptions.get(NO_PROXY));
         if (driverOptions.has(CLI_ARGS))
             options.addArguments(driverOptions.getCliArgs());
         if (driverOptions.has(CHROME_EXTENSION))


### PR DESCRIPTION
This pull requests adds --no-proxy support for chromedriver

The documentation describes --no-proxy as a general option.
But in the current implementation of ChromeDriverFactory --no-proxy is not evaluated.
Instead the user has to set --cli-args --proxy-bypass-list="hosts" which is not user friendly.

