### PR TITLE
add new option `--disable-page-information` to disable getting all/particular page information

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -1,6 +1,7 @@
 package jp.vmi.selenium.selenese;
 
 import java.io.PrintStream;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.openqa.selenium.JavascriptExecutor;
@@ -236,6 +237,13 @@ public interface Context extends WrapsDriver {
      * @param pageInformation page information.
      */
     void setLatestPageInformation(PageInformation pageInformation);
+
+    /**
+     * Get list of disabled page information.
+     *
+     * @return list of disabled page information.
+     */
+    EnumSet<PageInformation.Type> getDisabledPageInformation();
 
     /**
      * Get cookie filter.

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -3,10 +3,12 @@ package jp.vmi.selenium.selenese;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
@@ -180,6 +182,26 @@ public class Main {
             String[] rollups = config.getRollup();
             for (String rollup : rollups)
                 runner.getRollupRules().load(rollup);
+        }
+        if (config.getDisablePageInformation() != null) {
+            for (String s : config.getDisablePageInformation()) {
+                String uc = s.toUpperCase();
+                switch (uc) {
+                case "YES":
+                case "ALL":
+                    Collections.addAll(runner.getDisabledPageInformation(), PageInformation.Type.values());
+                    break;
+                case "NO":
+                    runner.getDisabledPageInformation().clear();
+                    break;
+                default:
+                    try {
+                        runner.getDisabledPageInformation().add(PageInformation.Type.valueOf(uc));
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException("Invalid value for --" + IConfig.DISABLE_PAGE_INFORMATION + ": " + s);
+                    }
+                }
+            }
         }
         if (config.getCookieFilter() != null) {
             String cookieFilter = config.getCookieFilter();

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -1,6 +1,7 @@
 package jp.vmi.selenium.selenese;
 
 import java.io.PrintStream;
+import java.util.EnumSet;
 
 import org.openqa.selenium.WebDriver;
 
@@ -142,6 +143,11 @@ public class NullContext implements Context {
 
     @Override
     public void setLatestPageInformation(PageInformation pageInformation) {
+    }
+
+    @Override
+    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
+        return null;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -8,6 +8,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Deque;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -89,6 +90,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private final Deque<HighlightStyleBackup> styleBackups;
 
     private PageInformation latestPageInformation = PageInformation.EMPTY;
+    private EnumSet<PageInformation.Type> disabledPageInformation = EnumSet.noneOf(PageInformation.Type.class);
     private CookieFilter cookieFilter = CookieFilter.ALL_PASS;
 
     private JSLibrary jsLibrary = new JSLibrary();
@@ -526,6 +528,11 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     @Override
     public void setLatestPageInformation(PageInformation pageInformation) {
         this.latestPageInformation = pageInformation;
+    }
+
+    @Override
+    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
+        return this.disabledPageInformation;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -194,6 +194,9 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--cookie-filter", metaVar = "<+RE|-RE>", usage = "filter cookies to log by RE matching the name. (\"+\" is passing, \"-\" is ignoring)")
     private String cookieFilter;
 
+    @Option(name = "--disable-page-information", metaVar = "<yes|all|no|cookie|title|url>", usage = "disable getting all/particular page information. (multiple)")
+    private String[] disablePageInformation;
+
     @Option(name = "--command-factory", metaVar = "<FQCN>", usage = "register user defined command factory. (See Note *3)")
     private String commandFactory;
 
@@ -549,6 +552,15 @@ public class DefaultConfig implements IConfig {
     @Override
     public String getCookieFilter() {
         return cookieFilter != null ? cookieFilter : (parentOptions != null ? parentOptions.getCookieFilter() : null);
+    }
+
+    @Override
+    public String[] getDisablePageInformation() {
+        return disablePageInformation != null ? disablePageInformation : (parentOptions != null ? parentOptions.getDisablePageInformation() : null);
+    }
+
+    public void addDisablePageInformation(String pageInfoType) {
+        this.disablePageInformation = ArrayUtils.add(this.disablePageInformation, pageInfoType);
     }
 
     public void setCookieFilter(String cookieFilter) {

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -54,6 +54,7 @@ public interface IConfig {
     public static final String VAR = "var";
     public static final String ROLLUP = "rollup";
     public static final String COOKIE_FILTER = "cookie-filter";
+    public static final String DISABLE_PAGE_INFORMATION = "disable-page-information";
     public static final String COMMAND_FACTORY = "command-factory";
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
@@ -157,6 +158,8 @@ public interface IConfig {
     String[] getRollup();
 
     String getCookieFilter();
+
+    String[] getDisablePageInformation();
 
     String getCommandFactory();
 

--- a/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
@@ -25,7 +25,7 @@ public class CommandLogInterceptor extends AbstractDoCommandInterceptor {
 
     private void logResult(LogRecorder clr, String indent, String cmdStr, Result result, Context context) {
         PageInformation prevInfo = context.getLatestPageInformation();
-        PageInformation info = new PageInformation(context);
+        PageInformation info = context.getDisabledPageInformation().equals(PageInformation.Type.ALL) ? PageInformation.EMPTY : new PageInformation(context);
         CookieFilter cookieFilter = context.getCookieFilter();
         String prefix = indent + "- Cookie: ";
         if (result.isFailed()) {

--- a/src/test/java/jp/vmi/selenium/selenese/MainTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/MainTest.java
@@ -3,7 +3,10 @@ package jp.vmi.selenium.selenese;
 import java.util.List;
 import java.util.Map;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import jp.vmi.selenium.selenese.config.DefaultConfig;
@@ -62,5 +65,50 @@ public class MainTest {
         assertThat(value5.get("A"), is(1.0));
         assertThat(value5.get("B"), is(2.0));
         assertThat(value5.get("C"), is(3.0));
+    }
+
+    @Rule
+    public ExpectedException ee = ExpectedException.none();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDisablePageInformationOption() {
+        Main main = new Main();
+        Runner runner = new Runner();
+        IConfig config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "all");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().equals(PageInformation.Type.ALL), is(true));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "cookie",
+            "--disable-page-information", "title");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(true));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(true));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(false));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "cookie",
+            "--disable-page-information", "title",
+            "--disable-page-information", "no",
+            "--disable-page-information", "url");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(false));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(false));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(true));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "foo");
+        ee.expect(IllegalArgumentException.class);
+        ee.expectMessage("Invalid value for --disable-page-information: foo");
+        main.setupRunner(runner, config);
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
@@ -1,5 +1,6 @@
 package jp.vmi.selenium.selenese.config;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -50,6 +51,7 @@ public class DefaultConfigTest {
         "--" + ROLLUP + "=/opt/path/to/rollup",
         "--" + COOKIE_FILTER + "=^OPT_SID",
         "--" + COMMAND_FACTORY + "=opt.full.qualify.class.Name",
+        "--" + DISABLE_PAGE_INFORMATION + "=cookie"
     };
 
     @Test
@@ -88,6 +90,7 @@ public class DefaultConfigTest {
         assertThat(config.get(ROLLUP), is(nullValue()));
         assertThat(config.get(COOKIE_FILTER), is(nullValue()));
         assertThat(config.get(COMMAND_FACTORY), is(nullValue()));
+        assertThat(config.get(DISABLE_PAGE_INFORMATION), is(nullValue()));
         assertThat(config.getArgs(), is(emptyArray()));
     }
 
@@ -128,6 +131,7 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("full.qualify.class.Name"));
+        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "all" }));
     }
 
     @Test
@@ -168,5 +172,6 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/opt/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^OPT_SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("opt.full.qualify.class.Name"));
+        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "cookie" }));
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
@@ -88,6 +88,8 @@ public class NewDefaultConfigTest {
         "--strict-exit-code",
         "--help",
         "--define", "--define",
+        "--disable-page-information", "title",
+        "--disable-page-information", "url",
         "arg1", "arg2", "arg3"
     };
 
@@ -134,6 +136,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(false));
         assertThat(options.isStrictExitCode(), is(false));
         assertThat(options.isHelp(), is(false));
+        assertThat(options.getDisablePageInformation(), is(nullValue()));
         assertThat(options.getArgs(), is(emptyArray()));
 
         options.parseCommandLine(testArgs);
@@ -176,6 +179,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(true));
         assertThat(options.isStrictExitCode(), is(true));
         assertThat(options.isHelp(), is(true));
+        assertThat(options.getDisablePageInformation(), is(new String[] { "title", "url" }));
         assertThat(options.getArgs(), is(new String[] { "arg1", "arg2", "arg3" }));
     }
 

--- a/src/test/resources/config/test.config
+++ b/src/test/resources/config/test.config
@@ -38,3 +38,4 @@ define:
 rollup: /path/to/rollup
 cookie-filter: ^SID
 command-factory: full.qualify.class.Name
+disable-page-information: all


### PR DESCRIPTION
selenese-runner-java's getting page information after each command execution feature is usually very useful (and I like this feature), but there are cases where it is useful or necessary to be able to disable this feature. e.g.:

- Disable getting cookie information is workaround of [this IEDriver's bug](https://github.com/SeleniumHQ/selenium/issues/4288). 
- To reduce client - server communications by turning off getting page information is helpful to speed up executing test case, especially when using RemoteWebDriver.

This PR add `--disable-page-information` option to disable getting all or particular page information.
