### PR TITLE
change the option name and parameters of PR #253

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Usage
      --define (-D) <key>[:<type>][+]=<value> : define parameters for capabilities. <type> is a value type: str (default), int or bool (multiple)
      --var (-V) <var-name>=<json-value>      : set JSON value to variable with a specified name. (multiple)
      --rollup <file>                         : define rollup rule by JavaScript. (multiple)
-     --cookie-filter <+RE|-RE>               : filter cookies to log by RE matching the name. ("+" is passing, "-" is ignoring)
+     --cookie-filter <+RE|-RE>               : filter cookies to log by RE matching the name. ("+" is passing, "-" is suppressing)
+     --log-filter <+type|-type>              : filter the logging information by the specified type. (multiple. "+" is passing, "-" is suppressing. type: cookie, title, url, pageinfo(= cookie & title & url))
      --command-factory <FQCN>                : register user defined command factory. (See Note *3)
      --no-exit                               : don't call System.exit at end.
      --strict-exit-code                      : return strict exit code, reflected by selenese command results at end. (See Note *4)

--- a/RELEASENOTE.md
+++ b/RELEASENOTE.md
@@ -6,6 +6,7 @@ Selenese Runner Java Relase Note
 * Catch up Selenium 3.8.1.
     * Fix some problems.
 * Update dependency versions.
+* Add `--log-filter` support to suppress page information in log. (#260, PR #253 by koichirok)
 
 ### 3.8.0
 

--- a/RELEASENOTE.md
+++ b/RELEASENOTE.md
@@ -1,12 +1,17 @@
 Selenese Runner Java Relase Note
 ================================
 
+### 3.10.0
+
+* Add `--log-filter` support to suppress page information in log. (#260, PR #253 by koichirok)
+
 ### 3.9.0
 
 * Catch up Selenium 3.8.1.
     * Fix some problems.
 * Update dependency versions.
-* Add `--log-filter` support to suppress page information in log. (#260, PR #253 by koichirok)
+* Add new command: `editContent`. (PR #261 by @apcros)
+* If the value of the variable is mathematically an integer, it is expanded as an integer. (#258)
 
 ### 3.8.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>jp.vmi</groupId>
   <artifactId>selenese-runner-java</artifactId>
-  <version>3.8.1-SNAPSHOT</version>
+  <version>3.9.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>selenese-runner-java</name>
@@ -47,7 +47,7 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
     <skipTests>true</skipTests>
     <selenium.version>3.8.1</selenium.version>
     <htmlunit.version>2.28</htmlunit.version>
-    <htmlunit-driver.version>2.28</htmlunit-driver.version>
+    <htmlunit-driver.version>2.28.2</htmlunit-driver.version>
     <httpclient.version>4.5.4</httpclient.version>
     <httpcore.version>4.4.8</httpcore.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -15,6 +15,7 @@ import jp.vmi.selenium.selenese.command.ICommandFactory;
 import jp.vmi.selenium.selenese.javascript.JSLibrary;
 import jp.vmi.selenium.selenese.locator.WebDriverElementFinder;
 import jp.vmi.selenium.selenese.log.CookieFilter;
+import jp.vmi.selenium.selenese.log.LogFilter;
 import jp.vmi.selenium.selenese.log.PageInformation;
 import jp.vmi.selenium.selenese.subcommand.SubCommandMap;
 
@@ -243,7 +244,7 @@ public interface Context extends WrapsDriver {
      *
      * @return list of disabled page information.
      */
-    EnumSet<PageInformation.Type> getDisabledPageInformation();
+    EnumSet<LogFilter> getLogFilter();
 
     /**
      * Get cookie filter.

--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -1,6 +1,7 @@
 package jp.vmi.selenium.selenese;
 
 import java.io.PrintStream;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.openqa.selenium.JavascriptExecutor;
@@ -236,6 +237,13 @@ public interface Context extends WrapsDriver {
      * @param pageInformation page information.
      */
     void setLatestPageInformation(PageInformation pageInformation);
+
+    /**
+     * Get list of disabled page information.
+     *
+     * @return list of disabled page information.
+     */
+    EnumSet<PageInformation.Type> getDisabledPageInformation();
 
     /**
      * Get cookie filter.

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -3,10 +3,12 @@ package jp.vmi.selenium.selenese;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
@@ -180,6 +182,26 @@ public class Main {
             String[] rollups = config.getRollup();
             for (String rollup : rollups)
                 runner.getRollupRules().load(rollup);
+        }
+        if (config.getDisablePageInformation() != null) {
+            for (String s : config.getDisablePageInformation()) {
+                String uc = s.toUpperCase();
+                switch (uc) {
+                case "YES":
+                case "ALL":
+                    Collections.addAll(runner.getDisabledPageInformation(), PageInformation.Type.values());
+                    break;
+                case "NO":
+                    runner.getDisabledPageInformation().clear();
+                    break;
+                default:
+                    try {
+                        runner.getDisabledPageInformation().add(PageInformation.Type.valueOf(uc));
+                    } catch (Exception e) {
+                        throw new IllegalArgumentException("Invalid value for --" + IConfig.DISABLE_PAGE_INFORMATION + ": " + s);
+                    }
+                }
+            }
         }
         if (config.getCookieFilter() != null) {
             String cookieFilter = config.getCookieFilter();

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -3,12 +3,10 @@ package jp.vmi.selenium.selenese;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.util.Collections;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
@@ -22,6 +20,7 @@ import jp.vmi.selenium.selenese.config.DefaultConfig;
 import jp.vmi.selenium.selenese.config.IConfig;
 import jp.vmi.selenium.selenese.log.CookieFilter;
 import jp.vmi.selenium.selenese.log.CookieFilter.FilterType;
+import jp.vmi.selenium.selenese.log.LogFilter;
 import jp.vmi.selenium.selenese.result.Result;
 import jp.vmi.selenium.selenese.utils.LoggerUtils;
 import jp.vmi.selenium.webdriver.DriverOptions;
@@ -183,25 +182,8 @@ public class Main {
             for (String rollup : rollups)
                 runner.getRollupRules().load(rollup);
         }
-        if (config.getDisablePageInformation() != null) {
-            for (String s : config.getDisablePageInformation()) {
-                String uc = s.toUpperCase();
-                switch (uc) {
-                case "YES":
-                case "ALL":
-                    Collections.addAll(runner.getDisabledPageInformation(), PageInformation.Type.values());
-                    break;
-                case "NO":
-                    runner.getDisabledPageInformation().clear();
-                    break;
-                default:
-                    try {
-                        runner.getDisabledPageInformation().add(PageInformation.Type.valueOf(uc));
-                    } catch (Exception e) {
-                        throw new IllegalArgumentException("Invalid value for --" + IConfig.DISABLE_PAGE_INFORMATION + ": " + s);
-                    }
-                }
-            }
+        if (config.getLogFilter() != null) {
+            LogFilter.parse(runner.getLogFilter(), config.getLogFilter());
         }
         if (config.getCookieFilter() != null) {
             String cookieFilter = config.getCookieFilter();

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -11,6 +11,7 @@ import jp.vmi.selenium.selenese.command.ICommandFactory;
 import jp.vmi.selenium.selenese.javascript.JSLibrary;
 import jp.vmi.selenium.selenese.locator.WebDriverElementFinder;
 import jp.vmi.selenium.selenese.log.CookieFilter;
+import jp.vmi.selenium.selenese.log.LogFilter;
 import jp.vmi.selenium.selenese.log.PageInformation;
 import jp.vmi.selenium.selenese.subcommand.SubCommandMap;
 
@@ -146,7 +147,7 @@ public class NullContext implements Context {
     }
 
     @Override
-    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
+    public EnumSet<LogFilter> getLogFilter() {
         return null;
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -1,6 +1,7 @@
 package jp.vmi.selenium.selenese;
 
 import java.io.PrintStream;
+import java.util.EnumSet;
 
 import org.openqa.selenium.WebDriver;
 
@@ -142,6 +143,11 @@ public class NullContext implements Context {
 
     @Override
     public void setLatestPageInformation(PageInformation pageInformation) {
+    }
+
+    @Override
+    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
+        return null;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -8,6 +8,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Deque;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -88,6 +89,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private final Deque<HighlightStyleBackup> styleBackups;
 
     private PageInformation latestPageInformation = PageInformation.EMPTY;
+    private EnumSet<PageInformation.Type> disabledPageInformation = EnumSet.noneOf(PageInformation.Type.class);
     private CookieFilter cookieFilter = CookieFilter.ALL_PASS;
 
     private JSLibrary jsLibrary = new JSLibrary();
@@ -525,6 +527,11 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     @Override
     public void setLatestPageInformation(PageInformation pageInformation) {
         this.latestPageInformation = pageInformation;
+    }
+
+    @Override
+    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
+        return this.disabledPageInformation;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -42,6 +42,7 @@ import jp.vmi.selenium.selenese.javascript.JSLibrary;
 import jp.vmi.selenium.selenese.locator.Locator;
 import jp.vmi.selenium.selenese.locator.WebDriverElementFinder;
 import jp.vmi.selenium.selenese.log.CookieFilter;
+import jp.vmi.selenium.selenese.log.LogFilter;
 import jp.vmi.selenium.selenese.log.PageInformation;
 import jp.vmi.selenium.selenese.result.Result;
 import jp.vmi.selenium.selenese.subcommand.SubCommandMap;
@@ -89,7 +90,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private final Deque<HighlightStyleBackup> styleBackups;
 
     private PageInformation latestPageInformation = PageInformation.EMPTY;
-    private EnumSet<PageInformation.Type> disabledPageInformation = EnumSet.noneOf(PageInformation.Type.class);
+    private final EnumSet<LogFilter> logFilter = LogFilter.all();
     private CookieFilter cookieFilter = CookieFilter.ALL_PASS;
 
     private JSLibrary jsLibrary = new JSLibrary();
@@ -530,8 +531,8 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     }
 
     @Override
-    public EnumSet<PageInformation.Type> getDisabledPageInformation() {
-        return this.disabledPageInformation;
+    public EnumSet<LogFilter> getLogFilter() {
+        return this.logFilter;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
@@ -64,6 +64,7 @@ public class CommandFactory implements ICommandFactory {
         addConstructor(DragAndDrop.class, "dragdrop");
         addConstructor(DragAndDropToObject.class);
         addConstructor(Echo.class);
+        addConstructor(EditContent.class);
         addConstructor(FireEvent.class);
         addConstructor(Focus.class);
         addConstructor(GoBack.class);

--- a/src/main/java/jp/vmi/selenium/selenese/command/EditContent.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/EditContent.java
@@ -1,0 +1,46 @@
+package jp.vmi.selenium.selenese.command;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.openqa.selenium.JavascriptException;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.result.Failure;
+import jp.vmi.selenium.selenese.result.Result;
+
+import static jp.vmi.selenium.selenese.command.ArgumentType.*;
+import static jp.vmi.selenium.selenese.result.Success.*;
+
+/**
+ * Command "EditContent".
+ * Not supported officially by Selenium IDE as of 23/11/2017
+ * But present and useable in their new port of SideeX
+ */
+public class EditContent extends AbstractCommand {
+
+    private static final int ARG_LOCATOR = 0;
+    private static final int ARG_VALUE = 1;
+
+    EditContent(int index, String name, String... args) {
+        super(index, name, args, LOCATOR, VALUE);
+    }
+
+    @Override
+    protected Result executeImpl(Context context, String... curArgs) {
+        String locator = curArgs[ARG_LOCATOR];
+        String value = curArgs[ARG_VALUE];
+
+        WebDriver driver = context.getWrappedDriver();
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        WebElement element = context.getElementFinder().findElement(driver, locator);
+        String javascriptEscaped = StringEscapeUtils.escapeEcmaScript(value);
+        try {
+            js.executeScript("var el = arguments[0]; el.innerHTML = '" + javascriptEscaped + "';", element);
+            return SUCCESS;
+        } catch (JavascriptException e) {
+            return new Failure(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -193,6 +193,9 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--cookie-filter", metaVar = "<+RE|-RE>", usage = "filter cookies to log by RE matching the name. (\"+\" is passing, \"-\" is ignoring)")
     private String cookieFilter;
 
+    @Option(name = "--disable-page-information", metaVar = "<yes|all|no|cookie|title|url>", usage = "disable getting all/particular page information. (multiple)")
+    private String[] disablePageInformation;
+
     @Option(name = "--command-factory", metaVar = "<FQCN>", usage = "register user defined command factory. (See Note *3)")
     private String commandFactory;
 
@@ -548,6 +551,15 @@ public class DefaultConfig implements IConfig {
     @Override
     public String getCookieFilter() {
         return cookieFilter != null ? cookieFilter : (parentOptions != null ? parentOptions.getCookieFilter() : null);
+    }
+
+    @Override
+    public String[] getDisablePageInformation() {
+        return disablePageInformation != null ? disablePageInformation : (parentOptions != null ? parentOptions.getDisablePageInformation() : null);
+    }
+
+    public void addDisablePageInformation(String pageInfoType) {
+        this.disablePageInformation = ArrayUtils.add(this.disablePageInformation, pageInfoType);
     }
 
     public void setCookieFilter(String cookieFilter) {

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -190,11 +190,12 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--rollup", metaVar = "<file>", usage = "define rollup rule by JavaScript. (multiple)")
     private String[] rollup;
 
-    @Option(name = "--cookie-filter", metaVar = "<+RE|-RE>", usage = "filter cookies to log by RE matching the name. (\"+\" is passing, \"-\" is ignoring)")
+    @Option(name = "--cookie-filter", metaVar = "<+RE|-RE>", usage = "filter cookies to log by RE matching the name. (\"+\" is passing, \"-\" is suppressing)")
     private String cookieFilter;
 
-    @Option(name = "--disable-page-information", metaVar = "<yes|all|no|cookie|title|url>", usage = "disable getting all/particular page information. (multiple)")
-    private String[] disablePageInformation;
+    @Option(name = "--log-filter", metaVar = "<+type|-type>",
+        usage = "filter the logging information by the specified type. (multiple. \"+\" is passing, \"-\" is suppressing. type: cookie, title, url, pageinfo(= cookie & title & url))")
+    private String[] logFilter;
 
     @Option(name = "--command-factory", metaVar = "<FQCN>", usage = "register user defined command factory. (See Note *3)")
     private String commandFactory;
@@ -554,12 +555,12 @@ public class DefaultConfig implements IConfig {
     }
 
     @Override
-    public String[] getDisablePageInformation() {
-        return disablePageInformation != null ? disablePageInformation : (parentOptions != null ? parentOptions.getDisablePageInformation() : null);
+    public String[] getLogFilter() {
+        return logFilter != null ? logFilter : (parentOptions != null ? parentOptions.getLogFilter() : null);
     }
 
-    public void addDisablePageInformation(String pageInfoType) {
-        this.disablePageInformation = ArrayUtils.add(this.disablePageInformation, pageInfoType);
+    public void addLogFilter(String logFilter) {
+        this.logFilter = ArrayUtils.add(this.logFilter, logFilter);
     }
 
     public void setCookieFilter(String cookieFilter) {

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -54,7 +54,7 @@ public interface IConfig {
     public static final String VAR = "var";
     public static final String ROLLUP = "rollup";
     public static final String COOKIE_FILTER = "cookie-filter";
-    public static final String DISABLE_PAGE_INFORMATION = "disable-page-information";
+    public static final String LOG_FILTER = "log-filter";
     public static final String COMMAND_FACTORY = "command-factory";
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
@@ -159,7 +159,7 @@ public interface IConfig {
 
     String getCookieFilter();
 
-    String[] getDisablePageInformation();
+    String[] getLogFilter();
 
     String getCommandFactory();
 

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -54,6 +54,7 @@ public interface IConfig {
     public static final String VAR = "var";
     public static final String ROLLUP = "rollup";
     public static final String COOKIE_FILTER = "cookie-filter";
+    public static final String DISABLE_PAGE_INFORMATION = "disable-page-information";
     public static final String COMMAND_FACTORY = "command-factory";
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
@@ -157,6 +158,8 @@ public interface IConfig {
     String[] getRollup();
 
     String getCookieFilter();
+
+    String[] getDisablePageInformation();
 
     String getCommandFactory();
 

--- a/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
@@ -25,7 +25,7 @@ public class CommandLogInterceptor extends AbstractDoCommandInterceptor {
 
     private void logResult(LogRecorder clr, String indent, String cmdStr, Result result, Context context) {
         PageInformation prevInfo = context.getLatestPageInformation();
-        PageInformation info = new PageInformation(context);
+        PageInformation info = context.getDisabledPageInformation().equals(PageInformation.Type.ALL) ? PageInformation.EMPTY : new PageInformation(context);
         CookieFilter cookieFilter = context.getCookieFilter();
         String prefix = indent + "- Cookie: ";
         if (result.isFailed()) {

--- a/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
+++ b/src/main/java/jp/vmi/selenium/selenese/inject/CommandLogInterceptor.java
@@ -25,7 +25,7 @@ public class CommandLogInterceptor extends AbstractDoCommandInterceptor {
 
     private void logResult(LogRecorder clr, String indent, String cmdStr, Result result, Context context) {
         PageInformation prevInfo = context.getLatestPageInformation();
-        PageInformation info = context.getDisabledPageInformation().equals(PageInformation.Type.ALL) ? PageInformation.EMPTY : new PageInformation(context);
+        PageInformation info = PageInformation.newInstance(context);
         CookieFilter cookieFilter = context.getCookieFilter();
         String prefix = indent + "- Cookie: ";
         if (result.isFailed()) {

--- a/src/main/java/jp/vmi/selenium/selenese/log/LogFilter.java
+++ b/src/main/java/jp/vmi/selenium/selenese/log/LogFilter.java
@@ -1,0 +1,93 @@
+package jp.vmi.selenium.selenese.log;
+
+import java.util.EnumSet;
+
+import jp.vmi.selenium.selenese.config.IConfig;
+
+/**
+ * Log filter types.
+ */
+public enum LogFilter {
+    /** enable cookie logging. */
+    COOKIE,
+    /** enable title logging. */
+    TITLE,
+    /** enable URL logging. */
+    URL,
+    ;
+
+    /**
+     * Disable all page information logging.
+     *
+     * @return empty set of LogFilter.
+     */
+    public static EnumSet<LogFilter> none() {
+        return EnumSet.noneOf(LogFilter.class);
+    }
+
+    /**
+     * Enable all page information logging.
+     *
+     * @return full set of LogFilter.
+     */
+    public static EnumSet<LogFilter> all() {
+        return EnumSet.allOf(LogFilter.class);
+    }
+
+    /**
+     * Parse command line arguments for "--log-filter".
+     *
+     * @param logFilter log filter.
+     * @param args command line arguments.
+     */
+    public static void parse(EnumSet<LogFilter> logFilter, String[] args) {
+        for (String arg : args) {
+            if (arg.isEmpty())
+                throw new IllegalArgumentException("Invalid value for --" + IConfig.LOG_FILTER + " is empty.");
+            boolean add;
+            switch (arg.charAt(0)) {
+            case '+':
+                add = true;
+                break;
+            case '-':
+                add = false;
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid value for --" + IConfig.LOG_FILTER + ": " + arg);
+            }
+            switch (arg.substring(1)) {
+            case "pageinfo":
+                if (add) {
+                    logFilter.add(COOKIE);
+                    logFilter.add(TITLE);
+                    logFilter.add(URL);
+                } else {
+                    logFilter.remove(COOKIE);
+                    logFilter.remove(TITLE);
+                    logFilter.remove(URL);
+                }
+                break;
+            case "cookie":
+                if (add)
+                    logFilter.add(COOKIE);
+                else
+                    logFilter.remove(COOKIE);
+                break;
+            case "title":
+                if (add)
+                    logFilter.add(TITLE);
+                else
+                    logFilter.remove(TITLE);
+                break;
+            case "url":
+                if (add)
+                    logFilter.add(URL);
+                else
+                    logFilter.remove(URL);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid value for --" + IConfig.LOG_FILTER + ": " + arg);
+            }
+        }
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/utils/SeleniumUtils.java
+++ b/src/main/java/jp/vmi/selenium/selenese/utils/SeleniumUtils.java
@@ -1,6 +1,9 @@
 package jp.vmi.selenium.selenese.utils;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
@@ -12,6 +15,8 @@ import org.openqa.selenium.StaleElementReferenceException;
  * Utilities for Selenium.
  */
 public class SeleniumUtils {
+
+    private static final DecimalFormatSymbols US_FORMAT = DecimalFormatSymbols.getInstance(Locale.US);
 
     private SeleniumUtils() {
     }
@@ -159,6 +164,21 @@ public class SeleniumUtils {
     }
 
     /**
+     * Stringify the double value.
+     *
+     * If the double value is mathematically an integer, drop fraction part.
+     *
+     * @param d double value.
+     * @return stringified double value.
+     */
+    public static String doubleToString(double d) {
+        if (d % 1.0 == 0)
+            return new DecimalFormat("0", US_FORMAT).format(d);
+        else
+            return Double.toString(d);
+    }
+
+    /**
      * Convert to String from the result of execute().
      *
      * @param <T> the type of result object.
@@ -174,6 +194,8 @@ public class SeleniumUtils {
             return StringUtils.join((Iterable<?>) result, ',');
         else if (result instanceof Iterator)
             return StringUtils.join((Iterator<?>) result, ',');
+        else if (result instanceof Double)
+            return doubleToString((Double) result);
         else
             return result.toString();
     }

--- a/src/test/java/jp/vmi/selenium/selenese/MainTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/MainTest.java
@@ -3,7 +3,6 @@ package jp.vmi.selenium.selenese;
 import java.util.List;
 import java.util.Map;
 
-import jp.vmi.selenium.selenese.log.PageInformation;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -11,6 +10,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 
 import jp.vmi.selenium.selenese.config.DefaultConfig;
 import jp.vmi.selenium.selenese.config.IConfig;
+import jp.vmi.selenium.selenese.log.LogFilter;
 import jp.vmi.selenium.webdriver.DriverOptions;
 
 import static org.hamcrest.Matchers.*;
@@ -71,44 +71,42 @@ public class MainTest {
     public ExpectedException ee = ExpectedException.none();
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void testDisablePageInformationOption() {
+    public void testLogFilterOption() {
         Main main = new Main();
         Runner runner = new Runner();
         IConfig config = new DefaultConfig(
             "-d", "htmlunit",
-            "--disable-page-information", "all");
+            "--log-filter", "+pageinfo");
         main.setupRunner(runner, config);
-        assertThat(runner.getDisabledPageInformation().equals(PageInformation.Type.ALL), is(true));
+        assertThat(runner.getLogFilter(), is(LogFilter.all()));
 
         runner = new Runner();
         config = new DefaultConfig(
             "-d", "htmlunit",
-            "--disable-page-information", "cookie",
-            "--disable-page-information", "title");
+            "--log-filter", "-pageinfo",
+            "--log-filter", "+cookie",
+            "--log-filter", "+title");
         main.setupRunner(runner, config);
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(true));
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(true));
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(false));
+        assertThat(runner.getLogFilter().contains(LogFilter.COOKIE), is(true));
+        assertThat(runner.getLogFilter().contains(LogFilter.TITLE), is(true));
+        assertThat(runner.getLogFilter().contains(LogFilter.URL), is(false));
 
         runner = new Runner();
         config = new DefaultConfig(
             "-d", "htmlunit",
-            "--disable-page-information", "cookie",
-            "--disable-page-information", "title",
-            "--disable-page-information", "no",
-            "--disable-page-information", "url");
+            "--log-filter", "-cookie",
+            "--log-filter", "-title");
         main.setupRunner(runner, config);
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(false));
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(false));
-        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(true));
+        assertThat(runner.getLogFilter().contains(LogFilter.COOKIE), is(false));
+        assertThat(runner.getLogFilter().contains(LogFilter.TITLE), is(false));
+        assertThat(runner.getLogFilter().contains(LogFilter.URL), is(true));
 
         runner = new Runner();
         config = new DefaultConfig(
             "-d", "htmlunit",
-            "--disable-page-information", "foo");
+            "--log-filter", "foo");
         ee.expect(IllegalArgumentException.class);
-        ee.expectMessage("Invalid value for --disable-page-information: foo");
+        ee.expectMessage("Invalid value for --log-filter: foo");
         main.setupRunner(runner, config);
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/MainTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/MainTest.java
@@ -3,7 +3,10 @@ package jp.vmi.selenium.selenese;
 import java.util.List;
 import java.util.Map;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import jp.vmi.selenium.selenese.config.DefaultConfig;
@@ -62,5 +65,50 @@ public class MainTest {
         assertThat(value5.get("A"), is(1.0));
         assertThat(value5.get("B"), is(2.0));
         assertThat(value5.get("C"), is(3.0));
+    }
+
+    @Rule
+    public ExpectedException ee = ExpectedException.none();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDisablePageInformationOption() {
+        Main main = new Main();
+        Runner runner = new Runner();
+        IConfig config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "all");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().equals(PageInformation.Type.ALL), is(true));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "cookie",
+            "--disable-page-information", "title");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(true));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(true));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(false));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "cookie",
+            "--disable-page-information", "title",
+            "--disable-page-information", "no",
+            "--disable-page-information", "url");
+        main.setupRunner(runner, config);
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.COOKIE), is(false));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.TITLE), is(false));
+        assertThat(runner.getDisabledPageInformation().contains(PageInformation.Type.URL), is(true));
+
+        runner = new Runner();
+        config = new DefaultConfig(
+            "-d", "htmlunit",
+            "--disable-page-information", "foo");
+        ee.expect(IllegalArgumentException.class);
+        ee.expectMessage("Invalid value for --disable-page-information: foo");
+        main.setupRunner(runner, config);
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/VariableTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/VariableTest.java
@@ -46,4 +46,18 @@ public class VariableTest extends TestBase {
         assertThat(varsMap.replaceVarsForArray(new String[] { "abc", "${a}", "abc${a}bca" }),
             is(arrayContaining("abc", "XYZ", "abcXYZbca")));
     }
+
+    /**
+     * Test of replaceVariables(Number).
+     */
+    @Test
+    public void replaceVarsForNumber() {
+        VarsMap varsMap = runner.getVarsMap();
+        varsMap.put("a1", 1);
+        varsMap.put("a2", 1.0);
+        varsMap.put("a3", 1.5);
+        assertThat(varsMap.replaceVars("${a1}"), is(equalTo("1")));
+        assertThat(varsMap.replaceVars("${a2}"), is(equalTo("1")));
+        assertThat(varsMap.replaceVars("${a3}"), is(equalTo("1.5")));
+    }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
@@ -1,5 +1,6 @@
 package jp.vmi.selenium.selenese.config;
 
+import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -50,6 +51,7 @@ public class DefaultConfigTest {
         "--" + ROLLUP + "=/opt/path/to/rollup",
         "--" + COOKIE_FILTER + "=^OPT_SID",
         "--" + COMMAND_FACTORY + "=opt.full.qualify.class.Name",
+        "--" + DISABLE_PAGE_INFORMATION + "=cookie"
     };
 
     @Test
@@ -88,6 +90,7 @@ public class DefaultConfigTest {
         assertThat(config.get(ROLLUP), is(nullValue()));
         assertThat(config.get(COOKIE_FILTER), is(nullValue()));
         assertThat(config.get(COMMAND_FACTORY), is(nullValue()));
+        assertThat(config.get(DISABLE_PAGE_INFORMATION), is(nullValue()));
         assertThat(config.getArgs(), is(emptyArray()));
     }
 
@@ -128,6 +131,7 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("full.qualify.class.Name"));
+        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "all" }));
     }
 
     @Test
@@ -168,5 +172,6 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/opt/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^OPT_SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("opt.full.qualify.class.Name"));
+        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "cookie" }));
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
@@ -1,6 +1,5 @@
 package jp.vmi.selenium.selenese.config;
 
-import jp.vmi.selenium.selenese.log.PageInformation;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class DefaultConfigTest {
         "--" + ROLLUP + "=/opt/path/to/rollup",
         "--" + COOKIE_FILTER + "=^OPT_SID",
         "--" + COMMAND_FACTORY + "=opt.full.qualify.class.Name",
-        "--" + DISABLE_PAGE_INFORMATION + "=cookie"
+        "--" + LOG_FILTER + "=-cookie"
     };
 
     @Test
@@ -90,7 +89,7 @@ public class DefaultConfigTest {
         assertThat(config.get(ROLLUP), is(nullValue()));
         assertThat(config.get(COOKIE_FILTER), is(nullValue()));
         assertThat(config.get(COMMAND_FACTORY), is(nullValue()));
-        assertThat(config.get(DISABLE_PAGE_INFORMATION), is(nullValue()));
+        assertThat(config.get(LOG_FILTER), is(nullValue()));
         assertThat(config.getArgs(), is(emptyArray()));
     }
 
@@ -131,7 +130,7 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("full.qualify.class.Name"));
-        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "all" }));
+        assertThat(config.getLogFilter(), equalTo(new String[] { "-pageinfo", "+title", "+url" }));
     }
 
     @Test
@@ -172,6 +171,6 @@ public class DefaultConfigTest {
         assertThat(config.getRollup(), equalTo(new String[] { "/opt/path/to/rollup" }));
         assertThat((String) config.get(COOKIE_FILTER), is("^OPT_SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("opt.full.qualify.class.Name"));
-        assertThat(config.getDisablePageInformation(), equalTo(new String[] { "cookie" }));
+        assertThat(config.getLogFilter(), equalTo(new String[] { "-cookie" }));
     }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
@@ -88,8 +88,9 @@ public class NewDefaultConfigTest {
         "--strict-exit-code",
         "--help",
         "--define", "--define",
-        "--disable-page-information", "title",
-        "--disable-page-information", "url",
+        "--log-filter", "-all",
+        "--log-filter", "+title",
+        "--log-filter", "+url",
         "arg1", "arg2", "arg3"
     };
 
@@ -136,7 +137,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(false));
         assertThat(options.isStrictExitCode(), is(false));
         assertThat(options.isHelp(), is(false));
-        assertThat(options.getDisablePageInformation(), is(nullValue()));
+        assertThat(options.getLogFilter(), is(nullValue()));
         assertThat(options.getArgs(), is(emptyArray()));
 
         options.parseCommandLine(testArgs);
@@ -179,7 +180,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(true));
         assertThat(options.isStrictExitCode(), is(true));
         assertThat(options.isHelp(), is(true));
-        assertThat(options.getDisablePageInformation(), is(new String[] { "title", "url" }));
+        assertThat(options.getLogFilter(), is(new String[] { "-all", "+title", "+url" }));
         assertThat(options.getArgs(), is(new String[] { "arg1", "arg2", "arg3" }));
     }
 

--- a/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
@@ -88,6 +88,8 @@ public class NewDefaultConfigTest {
         "--strict-exit-code",
         "--help",
         "--define", "--define",
+        "--disable-page-information", "title",
+        "--disable-page-information", "url",
         "arg1", "arg2", "arg3"
     };
 
@@ -134,6 +136,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(false));
         assertThat(options.isStrictExitCode(), is(false));
         assertThat(options.isHelp(), is(false));
+        assertThat(options.getDisablePageInformation(), is(nullValue()));
         assertThat(options.getArgs(), is(emptyArray()));
 
         options.parseCommandLine(testArgs);
@@ -176,6 +179,7 @@ public class NewDefaultConfigTest {
         assertThat(options.isNoExit(), is(true));
         assertThat(options.isStrictExitCode(), is(true));
         assertThat(options.isHelp(), is(true));
+        assertThat(options.getDisablePageInformation(), is(new String[] { "title", "url" }));
         assertThat(options.getArgs(), is(new String[] { "arg1", "arg2", "arg3" }));
     }
 

--- a/src/test/resources/config/test.config
+++ b/src/test/resources/config/test.config
@@ -38,4 +38,7 @@ define:
 rollup: /path/to/rollup
 cookie-filter: ^SID
 command-factory: full.qualify.class.Name
-disable-page-information: all
+log-filter:
+  -pageinfo
+  +title
+  +url

--- a/src/test/resources/config/test.config
+++ b/src/test/resources/config/test.config
@@ -38,3 +38,4 @@ define:
 rollup: /path/to/rollup
 cookie-filter: ^SID
 command-factory: full.qualify.class.Name
+disable-page-information: all

--- a/src/test/resources/selenese/testcase_var.html
+++ b/src/test/resources/selenese/testcase_var.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>var test</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">var test</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/</td>
+	<td></td>
+</tr>
+<tr>
+	<td>echo</td>
+	<td>${testValue}</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
I changed the specification of #253 as follows:

* Change the option name to `--log-filter`.
    * Move parameter list from `metaVar` to `usage` because the width of the help message is too wide.
* Add `+`/`-` prefix like `--cookie-filter`. (`+` is passing and `-` is suppressing)
* Add `pageinfo` parameter and remove `all` parameter.
