### PR TITLE
add new commands to handle native alert dialog.

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -4,6 +4,7 @@ import java.io.PrintStream;
 import java.util.EnumSet;
 import java.util.List;
 
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -294,6 +295,13 @@ public interface Context extends WrapsDriver {
     boolean isInteractive();
 
     /**
+     * Get next native alert action.
+     *
+     * @return next native alert state
+     */
+    AlertAction getNextNativeAlertAction();
+
+    /**
      * Executes JavaScript in the context of the currently selected frame or window.
      *
      * see {@link JavascriptExecutor#executeScript(String, Object...)}.
@@ -307,5 +315,25 @@ public interface Context extends WrapsDriver {
         @SuppressWarnings("unchecked")
         T result = (T) ((JavascriptExecutor) getWrappedDriver()).executeScript(script, args);
         return result;
+    }
+
+    /**
+     * action class for <i>native</i> alert dialog.
+     */
+    interface AlertAction {
+        /**
+         * Set whether or not to accept next alert dialog. <code>true</code> for accept, <code>false</code> for dismiss.
+         */
+        void setAccept(boolean accept);
+
+        /**
+         * Set the answer for <i>native</i> alert dialog.
+         */
+        void setAnswer(String answer);
+
+        /**
+         * Performs the action to <code>alert</code>. After perform, instance behaviour should be reset.
+         */
+        void perform(Alert alert);
     }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -182,4 +182,9 @@ public class NullContext implements Context {
     public boolean isInteractive() {
         return false;
     }
+
+    @Override
+    public AlertAction getNextNativeAlertAction() {
+        return null;
+    }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.openqa.selenium.Alert;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -101,6 +102,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
 
     private MaxTimeTimer maxTimeTimer = new MaxTimeTimer() {
     };
+    private AlertAction alertAction = new AlertAction();
 
     /**
      * Constructor.
@@ -384,6 +386,40 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     @Override
     public boolean isInteractive() {
         return isInteractive;
+    }
+
+    class AlertAction implements Context.AlertAction {
+        boolean accept = true;
+        String answer = null;
+
+        @Override
+        public void setAccept(boolean accept) {
+            this.accept = accept;
+        }
+        @Override
+        public void setAnswer(String answer) {
+            this.answer = answer;
+        }
+
+        @Override
+        public void perform(Alert alert) {
+            if (answer != null) {
+                alert.sendKeys(answer);
+            }
+            if (accept) {
+                alert.accept();
+            } else {
+                alert.dismiss();
+            }
+            // reset the behavior
+            this.answer = null;
+            this.accept = true;
+        }
+    }
+
+    @Override
+    public Context.AlertAction getNextNativeAlertAction() {
+        return this.alertAction;
     }
 
     /**

--- a/src/main/java/jp/vmi/selenium/selenese/command/AnswerOnNextNativeAlert.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/AnswerOnNextNativeAlert.java
@@ -1,0 +1,27 @@
+package jp.vmi.selenium.selenese.command;
+
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.result.Result;
+
+import static jp.vmi.selenium.selenese.command.ArgumentType.VALUE;
+import static jp.vmi.selenium.selenese.result.Success.SUCCESS;
+
+public class AnswerOnNextNativeAlert extends AbstractCommand {
+
+    private static final int ARG_ANSWER = 0;
+
+    AnswerOnNextNativeAlert(int index, String name, String... args) {
+        super(index, name, args, VALUE);
+    }
+
+    @Override
+    public boolean mayUpdateScreen() {
+        return false;
+    }
+
+    @Override
+    protected Result executeImpl(Context context, String... curArgs) {
+        context.getNextNativeAlertAction().setAnswer(curArgs[ARG_ANSWER]);
+        return SUCCESS;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/command/ChooseCancelOnNextNativeAlert.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/ChooseCancelOnNextNativeAlert.java
@@ -1,0 +1,19 @@
+package jp.vmi.selenium.selenese.command;
+
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.result.Result;
+
+import static jp.vmi.selenium.selenese.result.Success.SUCCESS;
+
+public class ChooseCancelOnNextNativeAlert extends AbstractCommand {
+
+    public ChooseCancelOnNextNativeAlert(int index, String name, String[] args) {
+        super(index, name, args);
+    }
+
+    @Override
+    protected Result executeImpl(Context context, String... curArgs) {
+        context.getNextNativeAlertAction().setAccept(false);
+        return SUCCESS;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/command/ChooseOkOnNextNativeAlert.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/ChooseOkOnNextNativeAlert.java
@@ -1,0 +1,19 @@
+package jp.vmi.selenium.selenese.command;
+
+import jp.vmi.selenium.selenese.Context;
+import jp.vmi.selenium.selenese.result.Result;
+
+import static jp.vmi.selenium.selenese.result.Success.SUCCESS;
+
+public class ChooseOkOnNextNativeAlert extends AbstractCommand {
+
+    public ChooseOkOnNextNativeAlert(int index, String name, String[] args) {
+        super(index, name, args);
+    }
+
+    @Override
+    protected Result executeImpl(Context context, String... curArgs) {
+        context.getNextNativeAlertAction().setAccept(true);
+        return SUCCESS;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandFactory.java
@@ -45,12 +45,15 @@ public class CommandFactory implements ICommandFactory {
         addConstructor(AltKeyDown.class);
         addConstructor(AltKeyUp.class);
         addConstructor(AnswerOnNextPrompt.class);
+        addConstructor(AnswerOnNextNativeAlert.class);
         addConstructor(AssignId.class);
         addConstructor(AttachFile.class);
         addConstructor(CaptureEntirePageScreenshot.class);
         addConstructor(Check.class);
         addConstructor(ChooseCancelOnNextConfirmation.class);
+        addConstructor(ChooseCancelOnNextNativeAlert.class);
         addConstructor(ChooseOkOnNextConfirmation.class);
+        addConstructor(ChooseOkOnNextNativeAlert.class);
         addConstructor(Click.class);
         addConstructor(ClickAt.class);
         addConstructor(Close.class);

--- a/src/main/java/jp/vmi/selenium/selenese/subcommand/GetNativeAlert.java
+++ b/src/main/java/jp/vmi/selenium/selenese/subcommand/GetNativeAlert.java
@@ -1,0 +1,15 @@
+package jp.vmi.selenium.selenese.subcommand;
+
+import jp.vmi.selenium.selenese.Context;
+import org.openqa.selenium.*;
+
+public class GetNativeAlert extends AbstractSubCommand<String> {
+
+    @Override
+    public String execute(Context context, String... args) {
+        Alert alert = context.getWrappedDriver().switchTo().alert();
+        String result = alert.getText();
+        context.getNextNativeAlertAction().perform(alert);
+        return result;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/subcommand/IsNativeAlertPresent.java
+++ b/src/main/java/jp/vmi/selenium/selenese/subcommand/IsNativeAlertPresent.java
@@ -1,0 +1,19 @@
+package jp.vmi.selenium.selenese.subcommand;
+
+import jp.vmi.selenium.selenese.Context;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.WebDriver;
+
+public class IsNativeAlertPresent extends AbstractSubCommand<Boolean> {
+    @Override
+    public Boolean execute(Context context, String... args) {
+        WebDriver driver = context.getWrappedDriver();
+        try {
+            driver.switchTo().alert();
+            return true;
+        } catch (NoAlertPresentException e) {
+
+        }
+        return false;
+    }
+}

--- a/src/main/java/jp/vmi/selenium/selenese/subcommand/SubCommandMap.java
+++ b/src/main/java/jp/vmi/selenium/selenese/subcommand/SubCommandMap.java
@@ -42,6 +42,7 @@ public class SubCommandMap {
         register(new GetExpression());
         register(new GetHtmlSource());
         register(new GetLocation());
+        register(new GetNativeAlert());
         register(new GetPrompt());
         register(new GetSelectOptions());
         register(new GetSpeed());
@@ -56,6 +57,7 @@ public class SubCommandMap {
         register(new IsCookiePresent());
         register(new IsEditable());
         register(new IsElementPresent());
+        register(new IsNativeAlertPresent());
         register(new IsOrdered());
         register(new IsPromptPresent());
         register(new IsSomethingSelected());

--- a/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
@@ -428,4 +428,11 @@ public class DriverDependentTest extends DriverDependentTestCaseTestBase {
         execute("contextMenu");
         assertThat(result, is(instanceOf(Success.class)));
     }
+
+    @Test
+    public void testNativeAlert() {
+        assumeNot(HTMLUNIT, PHANTOMJS);
+        execute("testcase_native_alert");
+        assertThat(result, is(instanceOf(Success.class)));
+    }
 }

--- a/src/test/resources/htdocs/native_alert.html
+++ b/src/test/resources/htdocs/native_alert.html
@@ -1,0 +1,58 @@
+<html>
+  <head>
+    <title>Native alert test</title>
+    <script><!--
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        $('alert_result').textContent = "done.";
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        $('confirm_result').textContent = result;
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.', '');
+        $('prompt_result').textContent = result;
+      }
+      function beforeunload_test(e) {
+        console.log('beforeunload_test');
+        var confirmationMessage = "Beforeunload dialog message";
+        e.returnValue = confirmationMessage;	// Gecko and Trident
+        return confirmationMessage;		// Gecko and WebKit
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>Dialog override test</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+      <li><a id="enable_beforeunload" onclick="window.addEventListener('beforeunload',beforeunload_test);">Enable beforeunload dialog</a></li>
+      <li><a id="goto_top" href="/">Go to top page</a></li>
+    </ul>
+  </body>
+  <script>
+<!--
+alert_test()
+confirm_test()
+prompt_test()
+-->
+  </script>
+</html>

--- a/src/test/resources/selenese/testcase_native_alert.html
+++ b/src/test/resources/selenese/testcase_native_alert.html
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>testcase_native_alert</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">testcase_native_alert</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/native_alert.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open alert dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseCancelOnNextNativeAlert</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open confirm dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>answerOnNextNativeAlert</td>
+	<td>prompt answer.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open prompt dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=alert_result</td>
+	<td>done.</td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=confirm_result</td>
+	<td>false</td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=prompt_result</td>
+	<td>prompt answer.</td>
+</tr>
+<tr>
+	<td>open</td>
+	<td>/native_alert.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open alert dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseCancelOnNextNativeAlert</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open confirm dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlert</td>
+	<td>open prompt dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertNativeAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=alert_result</td>
+	<td>done.</td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=confirm_result</td>
+	<td>false</td>
+</tr>
+<tr>
+	<td>assertText</td>
+	<td>id=prompt_result</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>id=enable_beforeunload</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=goto_top</td>
+	<td></td>
+</tr>
+<tr>
+	<!-- Google Chrome returns empty string for onbeforeunload dialog -->
+	<td>assertNativeAlert</td>
+	<td>*</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTitle</td>
+	<td>Index for Unit Test</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
This PR add new commands to handle *native* alert dialog.

Here *native* alerts means alerts not supported by legacy Selenium such as alerts generated in a page's
onload() event and so on.
I'm not sure that "native alert" is suitable name for such alerts. so feel free to change name from "native alert" if you have more suitable one :)
