### PR TITLE
Real entire page screenshot support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -659,6 +659,17 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
       <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.assertthat</groupId>
+      <artifactId>selenium-shutterbug</artifactId>
+      <version>0.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.seleniumhq.selenium</groupId>
+          <artifactId>selenium-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <reporting>
     <plugins>

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -221,6 +221,10 @@ public class Main {
             noExit = true;
         if (config.isStrictExitCode())
             exitStrictly = true;
+        int sstimeout = NumberUtils.toInt(config.getScreenshotScrollTimeout(), 100);
+        if (sstimeout < 0)
+            throw new IllegalArgumentException("Invalid screenshot scroll timeout value. (" + config.getScreenshotScrollTimeout() + ")");
+        runner.setScreenshotScrollTimeout(sstimeout);
         runner.setPrintStream(System.out);
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -84,6 +84,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private int timeout = 30 * 1000; /* ms */
     private long initialSpeed = 0; /* ms */
     private long speed = 0; /* ms */
+    private int screenshotScrollTimeout = 100; /* ms */
 
     private final Eval eval;
     private final SubCommandMap subCommandMap;
@@ -223,7 +224,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
 
                 Map initialCoord = (Map)je.executeScript(getScrollCoord);
 
-                Shutterbug.shootPage((WebDriver) tss, ScrollStrategy.BOTH_DIRECTIONS)
+                Shutterbug.shootPage((WebDriver) tss, ScrollStrategy.BOTH_DIRECTIONS, screenshotScrollTimeout)
                         .withName(FilenameUtils.removeExtension(tmp.getName()))
                         .save(dir.getPath());
 
@@ -465,6 +466,10 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
      */
     public void setW3cAction(Boolean isW3cAction) {
         this.isW3cAction = isW3cAction;
+    }
+
+    public void setScreenshotScrollTimeout(int timeout) {
+        this.screenshotScrollTimeout = timeout;
     }
 
     class AlertActionImpl implements AlertActionListener {

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -290,7 +290,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
         String filename = String.format("%s_%s_%d_fail.png", prefix, FILE_DATE_TIME.format(Calendar.getInstance()), index);
         try {
             File file = new File(screenshotOnFailDir, filename);
-            return takeScreenshot(tss, file);
+            return takeScreenshot(tss, file, true);
         } catch (WebDriverException e) {
             log.warn("- failed to capture screenshot: {} - {}", e.getClass().getSimpleName(), e.getMessage());
             return null;

--- a/src/main/java/jp/vmi/selenium/selenese/ScreenshotHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/ScreenshotHandler.java
@@ -13,6 +13,15 @@ public interface ScreenshotHandler {
     boolean isIgnoredScreenshotCommand();
 
     /**
+     * Take entire page screenshot to filename. (override directory if --screenshot-dir option specified)
+     *
+     * @param filename filename.
+     * @return screenshot image path.
+     * @exception UnsupportedOperationException WebDriver does not supoort capturing screenshot.
+     */
+    String takeEntirePageScreenshot(String filename) throws UnsupportedOperationException;
+
+    /**
      * Take screenshot to filename. (override directory if --screenshot-dir option specified)
      *
      * @param filename filename.

--- a/src/main/java/jp/vmi/selenium/selenese/command/CaptureEntirePageScreenshot.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CaptureEntirePageScreenshot.java
@@ -38,7 +38,7 @@ public class CaptureEntirePageScreenshot extends AbstractCommand {
         if (handler.isIgnoredScreenshotCommand())
             return new Success("captureEntirePageScreenshot is ignored.");
         try {
-            addScreenshot(handler.takeScreenshot(filename), "cmd");
+            addScreenshot(handler.takeEntirePageScreenshot(filename), "cmd");
             return SUCCESS;
         } catch (UnsupportedOperationException e) {
             return new Warning(e.getMessage());

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -218,6 +218,9 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--" + MAX_TIME, metaVar = "<max-time>", usage = "Maximum time in seconds that you allow the entire operation to take.")
     private String maxTime;
 
+    @Option(name = "--" + SCREENSHOT_SCROLL_TIMEOUT, metaVar = "<timeout>", usage = "set scroll timeout (ms) for taking screenshot. (default: 100)")
+    private String screenshotTimeout;
+
     @Option(name = "--" + HELP, aliases = "-h", usage = "show this message.")
     private Boolean help;
 
@@ -610,6 +613,15 @@ public class DefaultConfig implements IConfig {
 
     public void setCommandFactory(String commandFactory) {
         this.commandFactory = commandFactory;
+    }
+
+    @Override
+    public String getScreenshotScrollTimeout() {
+        return screenshotTimeout != null ? screenshotTimeout : (parentOptions != null ? parentOptions.getScreenshotScrollTimeout() : null);
+    }
+
+    public void setScreenshotTimeout(String timeout) {
+        this.screenshotTimeout = timeout;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -62,6 +62,7 @@ public interface IConfig {
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
     public static final String MAX_TIME = "max-time";
+    public static final String SCREENSHOT_SCROLL_TIMEOUT = "screenshot-scroll-timeout";
     public static final String HELP = "help";
 
     /**
@@ -169,6 +170,8 @@ public interface IConfig {
     String[] getLogFilter();
 
     String getCommandFactory();
+
+    String getScreenshotScrollTimeout();
 
     boolean isNoExit();
 


### PR DESCRIPTION
This PR contains following changes:

1. Make captureEntirePageScreenshot take screenshot for "entire page" 
2. Make  `--screenshot-on-fail`  take "entire page" screenshot. I believe full page screenshot is quite useful for this option.
3. Add `--screenshot-scroll-timeout` option to specify scroll timeout while taking screenshot for entire page

I'm not sure if  `--screenshot-scroll-timeout` is necessary or not, because my small tests with latest Firefox, Chrome and IE (with their latest WebDrivers) didn't need this option.

However, as mentioned in [Shutterbug's  Examples of usage page](https://github.com/assertthat/selenium-shutterbug/wiki/Examples-of-usage), there are some environment that need 500 ms of scroll timeout for taking full page screenshot in Chrome. This option will be useful in such a case.
