### PR TITLE
Improve old IE support.

### DIFF
--- a/src/main/resources/jp/vmi/selenium/selenese/javascript/JSLibrary.js
+++ b/src/main/resources/jp/vmi/selenium/selenese/javascript/JSLibrary.js
@@ -27,34 +27,61 @@
 //
 
 function replaceAlertMethod(element) {
-  window.localStorage.setItem('__webdriverAlerts', JSON.stringify([]));
-  window.alert = function(msg) {
-    var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
-    alerts.push(msg);
-    window.localStorage.setItem('__webdriverAlerts', JSON.stringify(alerts));
-  };
-  window.localStorage.setItem('__webdriverConfirms', JSON.stringify([]));
-  if (!('__webdriverNextConfirm' in window.localStorage))
-    window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(true));
-  window.confirm = function(msg) {
-    var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
-    confirms.push(msg);
-    window.localStorage.setItem('__webdriverConfirms', JSON.stringify(confirms));
-    var res = JSON.parse(window.localStorage.getItem('__webdriverNextConfirm'));
-    window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(true));
-    return res;
-  };
-  window.localStorage.setItem('__webdriverPrompts', JSON.stringify([]));
-  if (!('__webdriverNextPrompt' in window.localStorage))
-    window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(""));
-  window.prompt = function(msg) {
-    var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
-    prompts.push(msg);
-    window.localStorage.setItem('__webdriverPrompts', JSON.stringify(prompts));
-    var res = JSON.parse(window.localStorage.getItem('__webdriverNextPrompt'));
-    window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(""));
-    return res;
-  };
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    window.localStorage.setItem('__webdriverAlerts', JSON.stringify([]));
+    window.alert = function(msg) {
+      var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
+      alerts.push(msg);
+      window.localStorage.setItem('__webdriverAlerts', JSON.stringify(alerts));
+    };
+    window.localStorage.setItem('__webdriverConfirms', JSON.stringify([]));
+    if (!('__webdriverNextConfirm' in window.localStorage))
+      window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(true));
+    window.confirm = function(msg) {
+      var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
+      confirms.push(msg);
+      window.localStorage.setItem('__webdriverConfirms', JSON.stringify(confirms));
+      var res = JSON.parse(window.localStorage.getItem('__webdriverNextConfirm'));
+      window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(true));
+      return res;
+    };
+    window.localStorage.setItem('__webdriverPrompts', JSON.stringify([]));
+    if (!('__webdriverNextPrompt' in window.localStorage))
+      window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(""));
+    window.prompt = function(msg) {
+      var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
+      prompts.push(msg);
+      window.localStorage.setItem('__webdriverPrompts', JSON.stringify(prompts));
+      var res = JSON.parse(window.localStorage.getItem('__webdriverNextPrompt'));
+      window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(""));
+      return res;
+    };
+  } else {
+    window.__webdriverAlerts = [];
+    window.alert = function(msg) { window.__webdriverAlerts.push(msg); };
+    window.__webdriverConfirms = [];
+    if (typeof window.__webdriverNextConfirm === 'undefined')
+      window.__webdriverNextConfirm = true;
+    window.confirm = function(msg) {
+      window.__webdriverConfirms.push(msg);
+      var res = window.__webdriverNextConfirm;
+      window.__webdriverNextConfirm = true;
+      return res;
+    };
+    window.__webdriverPrompts = [];
+    if (typeof window.__webdriverNextPrompt === 'undefined')
+      window.__webdriverNextPrompt = true;
+    window.prompt = function(msg, def) {
+      window.__webdriverPrompts.push(msg || def);
+      var res = window.__webdriverNextPrompt;
+      window.__webdriverNextPrompt = true;
+      return res;
+    };
+  }
   var fw;
   if (element && (fw = element.ownerDocument.defaultView) && fw != window) {
     fw.alert = window.alert;
@@ -64,71 +91,140 @@ function replaceAlertMethod(element) {
 }
 
 function getNextAlert() {
-  if (!('__webdriverAlerts' in window.localStorage))
-    return null;
-  var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
-  if (! alerts)
-    return null;
-  var msg = alerts.shift();
-  window.localStorage.setItem('__webdriverAlerts', JSON.stringify(alerts));
-  if (msg)
-    msg = msg.replace(/\n/g, ' ');
-  return msg;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverAlerts' in window.localStorage))
+      return null;
+    var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
+    if (! alerts)
+      return null;
+    var msg = alerts.shift();
+    window.localStorage.setItem('__webdriverAlerts', JSON.stringify(alerts));
+    if (msg)
+      msg = msg.replace(/\n/g, ' ');
+    return msg;
+  } else {
+    if (!window.__webdriverAlerts) { return null }
+    var t = window.__webdriverAlerts.shift();
+    if (t) { t = t.replace(/\\n/g, ' '); }
+    return t;
+  }
 }
 
 function isAlertPresent() {
-  if (!('__webdriverAlerts' in window.localStorage))
-    return false;
-  var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
-  return alerts && alerts.length > 0;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverAlerts' in window.localStorage))
+      return false;
+    var alerts = JSON.parse(window.localStorage.getItem('__webdriverAlerts'));
+    return alerts && alerts.length > 0;
+  } else {
+    return window.__webdriverAlerts && window.__webdriverAlerts.length > 0;
+  }
 }
 
 function setNextConfirmationState(state) {
-  window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(state));
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    window.localStorage.setItem('__webdriverNextConfirm', JSON.stringify(state));
+  } else {
+    window.__webdriverNextConfirm = state;
+  }
 }
 
 function getNextConfirmation() {
-  if (!('__webdriverConfirms' in window.localStorage))
-    return null;
-  var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
-  if (! confirms)
-    return null;
-  var msg = confirms.shift();
-  window.localStorage.setItem('__webdriverConfirms', JSON.stringify(confirms));
-  if (msg)
-    msg = msg.replace(/\n/g, ' ');
-  return msg;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverConfirms' in window.localStorage))
+      return null;
+    var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
+    if (! confirms)
+      return null;
+    var msg = confirms.shift();
+    window.localStorage.setItem('__webdriverConfirms', JSON.stringify(confirms));
+    if (msg)
+      msg = msg.replace(/\n/g, ' ');
+    return msg;
+  } else {
+    if (!window.__webdriverConfirms) { return null; }
+    return window.__webdriverConfirms.shift();
+  }
 }
 
 function isConfirmationPresent() {
-  if (!('__webdriverConfirms' in window.localStorage))
-    return false;
-  var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
-  return confirms && confirms.length > 0;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverConfirms' in window.localStorage))
+      return false;
+    var confirms = JSON.parse(window.localStorage.getItem('__webdriverConfirms'));
+    return confirms && confirms.length > 0;
+  } else {
+    return window.__webdriverConfirms && window.__webdriverConfirms.length > 0;
+  }
 }
 
 function answerOnNextPrompt(answer) {
-  window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(answer));
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    window.localStorage.setItem('__webdriverNextPrompt', JSON.stringify(answer));
+  } else {
+    window.__webdriverNextPrompt = answer;
+  }
 }
 
 function getNextPrompt() {
-  if (!('__webdriverPrompts' in window.localStorage))
-    return null;
-  var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
-  if (!prompts)
-    return null;
-  var msg = prompts.shift();
-  window.localStorage.setItem('__webdriverPrompts', JSON.stringify(prompts));
-  if (msg)
-    msg = msg.replace(/\n/g, ' ');
-  return msg;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverPrompts' in window.localStorage))
+      return null;
+    var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
+    if (!prompts)
+      return null;
+    var msg = prompts.shift();
+    window.localStorage.setItem('__webdriverPrompts', JSON.stringify(prompts));
+    if (msg)
+      msg = msg.replace(/\n/g, ' ');
+    return msg;
+  } else {
+    if (!window.__webdriverPrompts) { return null; }
+    return window.__webdriverPrompts.shift();
+  }
 }
 
 function isPromptPresent() {
-  if (!('__webdriverPrompts' in window.localStorage))
-    return false;
-  var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
-  return prompts && prompts.length > 0;
+  var canUseLocalStorage = false;
+  try { canUseLocalStorage = !!window.localStorage; } catch(ex) { /* probe failed */ }
+  var canUseJSON = false;
+  try { canUseJSON = !!JSON; } catch(ex) { /* probe failed */ }
+  if (canUseLocalStorage && canUseJSON) {
+    if (!('__webdriverPrompts' in window.localStorage))
+      return false;
+    var prompts = JSON.parse(window.localStorage.getItem('__webdriverPrompts'));
+    return prompts && prompts.length > 0;
+  } else {
+    return window.__webdriverPrompts && window.__webdriverPrompts.length > 0;
+  }
 }
 
 //
@@ -245,8 +341,12 @@ function getTable(table, row, col) {
 
 function getText(element) {
   function isVisible(element) {
-    var style = getComputedStyle(element);
+    var style = (typeof getComputedStyle !== 'undefined') ? getComputedStyle(element) : element.currentStyle
     return style.display !== 'none' && style.visibility !== 'hidden';
+  }
+  function trim(text) {
+    // String.replace() version of trim obtained from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill
+    return String.prototype.trim ? text.trim() : text.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
   }
   function getTextInternal(element) {
     var texts = [];
@@ -274,12 +374,12 @@ function getText(element) {
         // skip
         break;
       default:
-        var text = node.textContent.replace(/[\u0000-\u0020]+/g, " ");
+        var text = (node.textContent || node.innerText || node.nodeValue).replace(/[\u0000-\u0020]+/g, " ");
         texts.push(text);
         break;
       }
     }
-    return texts.join("").replace(/ +/g, " ").trim();
+    return trim(texts.join("").replace(/ +/g, " "));
   }
   return getTextInternal(element);
 }

--- a/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
@@ -430,4 +430,11 @@ public class DriverDependentTest extends DriverDependentTestCaseTestBase {
         execute("testsuite_simple.side");
         assertThat(result, is(instanceOf(Success.class)));
     }
+
+    @Test
+    public void testIE() {
+        assumeThat(currentFactoryName, is(IE));
+        execute("testcase_ie");
+        assertThat(result, is(instanceOf(Success.class)));
+    }
 }

--- a/src/test/resources/htdocs/ie/ie10.html
+++ b/src/test/resources/htdocs/ie/ie10.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=10" />
+    <title>IE10 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE10 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/ie11.html
+++ b/src/test/resources/htdocs/ie/ie11.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=11" />
+    <title>IE11 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE11 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/ie5.html
+++ b/src/test/resources/htdocs/ie/ie5.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=5" />
+    <title>IE5 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE5 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/ie7.html
+++ b/src/test/resources/htdocs/ie/ie7.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=7" />
+    <title>IE7 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE7 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/ie8.html
+++ b/src/test/resources/htdocs/ie/ie8.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=8" />
+    <title>IE8 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE8 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/ie9.html
+++ b/src/test/resources/htdocs/ie/ie9.html
@@ -1,0 +1,61 @@
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=9" />
+    <title>IE9 Mode Test Page</title>
+    <script><!--
+      if (!window.console) window.console = {};
+      if (!window.console.log) window.console.log = function () {};
+      function setTextContent(element, value) {
+        if ('textContent' in element)
+          element.textContent = value;
+        else if ('innerText' in element)
+          element.innerText = value;
+      }
+      function $(id) {
+        return document.getElementById(id);
+      }
+      function alert_test() {
+        console.log('alert_test');
+        alert('open alert dialog.');
+        setTextContent($('alert_result'), "done.");
+      }
+      function confirm_test() {
+        console.log('confirm_test');
+        var result = confirm('open confirm dialog.');
+        setTextContent($('confirm_result'), result);
+      }
+      function prompt_test() {
+        console.log('prompt_test');
+        var result = prompt('open prompt dialog.');
+        setTextContent($('prompt_result'), result);
+      }
+    //--></script>
+  </head>
+  <body>
+    <h1>IE9 Mode Test Page</h1>
+    <hr>
+    <ul>
+      <li>alert
+        <button id="alert" onclick="alert_test()">alert</button><br>
+        Result: <span id="alert_result">-</span>
+      </li>
+      <li>confirm
+        <button id="confirm" onclick="confirm_test()">confirm</button><br>
+        Result: <span id="confirm_result">-</span>
+      </li>
+      <li>prompt
+        <button id="prompt" onclick="prompt_test()">prompt</button><br>
+        Result: <span id="prompt_result">-</span>
+      </li>
+    </ul>
+    <hr>
+    <div id="text_with_hidden">
+      <span> begin </span>
+      <span style="display:none">display:none</span>
+      <span style="visibility:hidden">visibility:hidden</span>
+      <span> end </span>
+    </div>
+    <hr>
+    <a href="index.html" id="back">Back</a>
+  </body>
+</html>

--- a/src/test/resources/htdocs/ie/index.html
+++ b/src/test/resources/htdocs/ie/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>IE Test with Document Modes</title>
+</head>
+<body>
+
+See <a href="https://msdn.microsoft.com/en-us/library/ff955275(v=vs.85).aspx">MSDN Document</a> for detail.
+
+<ul>
+<li><a href="./ie5.html">IE=5</a></li>
+<li><a href="./ie7.html">IE=7</a></li>
+<li><a href="./ie8.html">IE=8</a></li>
+<li><a href="./ie9.html">IE=9</a></li>
+<li><a href="./ie10.html">IE=10</a></li>
+<li><a href="./ie11.html">IE=11</a></li>
+</ul>
+</body>
+</html>

--- a/src/test/resources/selenese/testcase_ie.html
+++ b/src/test/resources/selenese/testcase_ie.html
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>IE test with Document Modes</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">IE test with Document Modes</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/ie/index.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>addCollection</td>
+	<td>MODES</td>
+	<td></td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>11</td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>10</td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>9</td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>8</td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>7</td>
+</tr>
+<tr>
+	<td>addToCollection</td>
+	<td>MODES</td>
+	<td>5</td>
+</tr>
+<tr>
+	<td>storeFor</td>
+	<td>MODES</td>
+	<td>MODE</td>
+</tr>
+<tr>
+	<td>echo</td>
+	<td>MODE=${MODE}</td>
+	<td></td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>link=IE=${MODE}</td>
+	<td></td>
+</tr>
+<tr>
+	<td>echo</td>
+	<td>javascript{"Document Mode: " + (document.documentMode || "Unsupported")}</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=alert</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyAlert</td>
+	<td>open alert dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=alert_result</td>
+	<td>done.</td>
+</tr>
+<tr>
+	<td>verifyAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>answerOnNextPrompt</td>
+	<td>prompt answer.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=prompt</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyPromptPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyPrompt</td>
+	<td>open prompt dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=prompt_result</td>
+	<td>prompt answer.</td>
+</tr>
+<tr>
+	<td>verifyPromptNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseOkOnNextConfirmation</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=confirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyConfirmationPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyConfirmation</td>
+	<td>open confirm dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=confirm_result</td>
+	<td>true</td>
+</tr>
+<tr>
+	<td>verifyConfirmationNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseCancelOnNextConfirmation</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=confirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyConfirmationPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=confirm_result</td>
+	<td>false</td>
+</tr>
+<tr>
+        <td>storeText</td>
+        <td>id=text_with_hidden</td>
+        <td>text</td>
+</tr>
+<tr>
+        <td>echo</td>
+        <td>&lt;${text}&gt;</td>
+        <td></td>
+</tr>
+<tr>
+        <td>assertExpression</td>
+        <td>${text}</td>
+        <td>begin end</td>
+</tr>
+<tr>
+	<td>clickAndWait</td>
+	<td>id=back</td>
+	<td></td>
+</tr>
+<tr>
+	<td>endFor</td>
+	<td></td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
Due to the lack of window.JSON, window.getCouputedStyle, Node's textContent property and String.trim()  in IE < 9, selenese-runner-java's commands that use DialogOverrid functions or getText() defeind in JSLibrary.js  failed to execute with JavaScript error.

This PR improve support for such a old IEs by adding workaround for above problems.



