### PR TITLE
add --max-retries <n> command line option to allow retrying failed commands

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -324,4 +324,32 @@ public interface Context extends WrapsDriver {
         T result = (T) ((JavascriptExecutor) getWrappedDriver()).executeScript(script, args);
         return result;
     }
+
+    /**
+     * Get number of actually used retries.
+     *
+     * @return number of actually used retries.
+     */
+    int getRetries();
+
+    /**
+     * Update the actual number of used retries.
+     *
+     * @param retries
+     */
+    void setRetries(int retries);
+
+    /**
+     * Get maximum number of retries allowed for a given test.
+     *
+     * @return the maximum number of retries allowed for a given test.
+     */
+    int getMaxRetries();
+
+    /**
+     * Set the maximum number of retries allowed for a given test.
+     *
+     * @param maxRetries
+     */
+    void setMaxRetries(int maxRetries);
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -213,6 +213,10 @@ public class Main {
         if (timeout <= 0)
             throw new IllegalArgumentException("Invalid timeout value. (" + config.getTimeout() + ")");
         runner.setTimeout(timeout);
+        int maxRetries = NumberUtils.toInt(config.getMaxRetries(), DEFAULT_MAX_RETRIES);
+        if ((maxRetries < 0) || (maxRetries > 10))
+            throw new IllegalArgumentException("Invalid value: 0 <= maxRetries <= 10. (" + config.getMaxRetries() + ")");
+        runner.setMaxRetries(maxRetries);
         int speed = NumberUtils.toInt(config.getSetSpeed(), 0);
         if (speed < 0)
             throw new IllegalArgumentException("Invalid speed value. (" + config.getSetSpeed() + ")");

--- a/src/main/java/jp/vmi/selenium/selenese/NullContext.java
+++ b/src/main/java/jp/vmi/selenium/selenese/NullContext.java
@@ -187,4 +187,28 @@ public class NullContext implements Context {
     public AlertActionListener getNextNativeAlertActionListener() {
         return null;
     }
+
+    @Override
+    public int getRetries() {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public void setRetries(int retries) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public int getMaxRetries() {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public void setMaxRetries(int maxRetries) {
+        // TODO Auto-generated method stub
+
+    }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -83,6 +83,8 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private boolean isInteractive = false;
     private Boolean isW3cAction = null;
     private int timeout = 30 * 1000; /* ms */
+    private int retries = 0;
+    private int maxRetries = 0;
     private long initialSpeed = 0; /* ms */
     private long speed = 0; /* ms */
     private int screenshotScrollTimeout = 100; /* ms */
@@ -538,6 +540,29 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
         if (driver != null)
             setDriverTimeout();
         log.info("Timeout: {} ms", timeout);
+    }
+
+    @Override
+    public int getRetries() {
+        return retries;
+    }
+
+    @Override
+    public void setRetries(int retries) {
+        this.retries = retries;
+        if (retries > 0)
+          log.info("Retry: {}", retries);
+    }
+
+    @Override
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    @Override
+    public void setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+        log.info("MaxRetries: {}", maxRetries);
     }
 
     /**

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -132,8 +132,10 @@ public class CommandList extends ArrayList<ICommand> {
                     result = doCommand(context, command, curArgs);
                     if (result.isSuccess())
                         break;
-                    context.setRetries(context.getRetries() + 1);
-                    context.waitSpeed();
+		    if (context.getMaxRetries() > 0) {
+                        context.setRetries(context.getRetries() + 1);
+                        context.waitSpeed();
+		    }
                 } while (context.getRetries() < context.getMaxRetries());
                 if (result.isAborted())
                     isContinued = false;

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -126,7 +126,15 @@ public class CommandList extends ArrayList<ICommand> {
                 int prevSSIndex = (ss == null) ? 0 : ss.size();
                 String[] curArgs = context.getVarsMap().replaceVarsForArray(command.getArguments());
                 evalCurArgs(context, curArgs);
-                Result result = doCommand(context, command, curArgs);
+                Result result = null;
+                context.setRetries(0);
+                do {
+                    result = doCommand(context, command, curArgs);
+                    if (result.isSuccess())
+                        break;
+                    context.setRetries(context.getRetries() + 1);
+                    context.waitSpeed();
+                } while (context.getRetries() < context.getMaxRetries());
                 if (result.isAborted())
                     isContinued = false;
                 else

--- a/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/CommandList.java
@@ -136,7 +136,7 @@ public class CommandList extends ArrayList<ICommand> {
                         context.setRetries(context.getRetries() + 1);
                         context.waitSpeed();
 		    }
-                } while (context.getRetries() < context.getMaxRetries());
+                } while ((context.getMaxRetries() > 0) && (context.getRetries() < context.getMaxRetries()));
                 if (result.isAborted())
                     isContinued = false;
                 else

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -39,6 +39,8 @@ public class DefaultConfig implements IConfig {
     public static final int DEFAULT_TIMEOUT_MILLISEC_N = 30000;
     public static final String DEFAULT_TIMEOUT_MILLISEC = Integer.toString(DEFAULT_TIMEOUT_MILLISEC_N);
 
+    public static final int DEFAULT_MAX_RETRIES = 0;
+
     // parts of help message.
     private static final String[] HEADER = {
         "Selenese script interpreter implemented by Java.",
@@ -175,6 +177,10 @@ public class DefaultConfig implements IConfig {
 
     @Option(name = "--" + TIMEOUT, aliases = "-t", metaVar = "<timeout>", usage = "set timeout (ms) for waiting. (default: " + DEFAULT_TIMEOUT_MILLISEC_N + " ms)")
     private String timeout;
+
+    @Option(name = "--" + MAXRETRIES, metaVar = "<maxRetries>",
+        usage = "set maximum number of retries for a given step. (default: " + DEFAULT_MAX_RETRIES + ")")
+    private String maxRetries;
 
     @Option(name = "--" + SET_SPEED, metaVar = "<speed>", usage = "same as executing setSpeed(ms) command first.")
     private String setSpeed;
@@ -523,6 +529,15 @@ public class DefaultConfig implements IConfig {
 
     public void setTimeout(String timeout) {
         this.timeout = timeout;
+    }
+
+    @Override
+    public String getMaxRetries() {
+        return maxRetries != null ? maxRetries : (parentOptions != null ? parentOptions.getMaxRetries() : null);
+    }
+
+    public void setMaxRetries(String maxRetries) {
+        this.maxRetries = maxRetries;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -49,6 +49,7 @@ public interface IConfig {
     public static final String XML_RESULT = "xml-result";
     public static final String HTML_RESULT = "html-result";
     public static final String TIMEOUT = "timeout";
+    public static final String MAXRETRIES = "max-retries";
     public static final String SET_SPEED = "set-speed";
     public static final String HEIGHT = "height";
     public static final String WIDTH = "width";
@@ -182,4 +183,6 @@ public interface IConfig {
     boolean isHelp();
 
     String getAlertsPolicy();
+
+    String getMaxRetries();
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/NewDefaultConfigTest.java
@@ -74,6 +74,7 @@ public class NewDefaultConfigTest {
         "--xml-result", "xml-result-dir",
         "--html-result", "html-result-dir",
         "--timeout", "timeout",
+        "--max-retries", "max-retries",
         "--set-speed", "speed",
         "--height", "screen-height",
         "--width", "screen-width",
@@ -132,6 +133,7 @@ public class NewDefaultConfigTest {
         assertThat(options.getXmlResult(), is(nullValue()));
         assertThat(options.getHtmlResult(), is(nullValue()));
         assertThat(options.getTimeout(), is(nullValue()));
+        assertThat(options.getMaxRetries(), is(nullValue()));
         assertThat(options.getSetSpeed(), is(nullValue()));
         assertThat(options.getHeight(), is(nullValue()));
         assertThat(options.getWidth(), is(nullValue()));
@@ -178,6 +180,7 @@ public class NewDefaultConfigTest {
         assertThat(options.getXmlResult(), is("xml-result-dir"));
         assertThat(options.getHtmlResult(), is("html-result-dir"));
         assertThat(options.getTimeout(), is("timeout"));
+        assertThat(options.getMaxRetries(), is("max-retries"));
         assertThat(options.getSetSpeed(), is("speed"));
         assertThat(options.getHeight(), is("screen-height"));
         assertThat(options.getWidth(), is("screen-width"));


### PR DESCRIPTION
I'd like selenese-runner-java to replace our proprietary in-house tool. According to users, one key missing feature is allowing retries and a report seeing how often retries were actually needed.

This patch attempts to implement this feature. Thanks in advance for considering it.