### PR TITLE
Exclude unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,14 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-opera-driver</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -649,10 +657,6 @@ It supports test-case and test-suite which are Selenium IDE's native format.</de
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Hello, I'm making this pull request because I noticed that `guava` was excluded from dependency `littleproxy` in commit https://github.com/vmi/selenese-runner-java/commit/9e6f39a71fc66f0310915265c2b7692897703960. Looking at the dependency tree at that time, I think this exclusion was made to fix a potential conflict between `guava` versions 19.0 (used by `selenium-api`) and version 14.0 (used by `littleproxy`). In that case, version 14.0 was put in the classpath because it was closer to the root of the project.  However, now  `selenium-java` declared `guava` version 25.0-jre as a direct dependency, avoiding the conflict. Therefore the exclusion can be removed without any problem.

On the other hand, I also noticed that `findbugs` and `selenium-opera-driver` are not used and can be excluded safely from `selenium-java`.