### PR TITLE
add option to disable replacement of alert funcions

### DIFF
--- a/src/generator/config.groovy
+++ b/src/generator/config.groovy
@@ -275,6 +275,11 @@ max_time {
     usage = "Maximum time in seconds that you allow the entire operation to take."
 }
 
+no_replace_alert_method {
+    usage = "disable replacement of alert methods"
+    type = "Boolean"
+}
+
 help {
     aliases = "-h"
     usage = "show this message."

--- a/src/main/java/jp/vmi/selenium/selenese/Context.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Context.java
@@ -427,4 +427,12 @@ public interface Context extends WrapsDriver, SubCommandMapProvider {
      */
     default void setupMaxTimeTimer(long maxTime) {
     }
+
+    /**
+     * Return whether to replace alert methods.
+     * @return <code>true</code> to replace alert method, <code>false</code> otherwise.
+     */
+    default boolean isReplaceAlertMethod() {
+        return true;
+    }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/Main.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Main.java
@@ -233,6 +233,8 @@ public class Main {
         if (sstimeout < 0)
             throw new IllegalArgumentException("Invalid screenshot scroll timeout value. (" + config.getScreenshotScrollTimeout() + ")");
         runner.setScreenshotScrollTimeout(sstimeout);
+        if (config.isNoReplaceAlertMethod())
+            runner.setReplaceAlertMethod(false);
         runner.setPrintStream(System.out);
     }
 

--- a/src/main/java/jp/vmi/selenium/selenese/Runner.java
+++ b/src/main/java/jp/vmi/selenium/selenese/Runner.java
@@ -85,6 +85,7 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     private boolean isIgnoredScreenshotCommand = false;
     private boolean isHighlight = false;
     private boolean isInteractive = false;
+    private boolean isReplaceAlertMethod = true;
     private Boolean isW3cAction = null;
     private int timeout = 30 * 1000; /* ms */
     private int retries = 0;
@@ -946,5 +947,18 @@ public class Runner implements Context, ScreenshotHandler, HighlightHandler, JUn
     @Override
     public void setupMaxTimeTimer(long maxTime) {
         this.maxTimeTimer = new MaxTimeActiveTimer(maxTime);
+    }
+
+    @Override
+    public boolean isReplaceAlertMethod() {
+        return this.isReplaceAlertMethod;
+    }
+
+    /**
+     * Set whether to repalce alert methods.
+     * @param replaceAlertMethod replace alert methods or not.
+     */
+    public void setReplaceAlertMethod(boolean replaceAlertMethod) {
+        this.isReplaceAlertMethod = replaceAlertMethod;
     }
 }

--- a/src/main/java/jp/vmi/selenium/selenese/command/Check.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Check.java
@@ -25,7 +25,8 @@ public class Check extends AbstractCommand {
         String locator = curArgs[ARG_LOCATOR];
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         if (!element.isSelected())
             element.click();
         return SUCCESS;

--- a/src/main/java/jp/vmi/selenium/selenese/command/ClickHandler.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/ClickHandler.java
@@ -25,7 +25,8 @@ final class ClickHandler {
         while (true) {
             WebElement element = context.getElementFinder().findElementWithTimeout(driver, locator, isRetryable, timeout);
             try {
-                context.getJSLibrary().replaceAlertMethod(driver, element);
+                if (context.isReplaceAlertMethod())
+                    context.getJSLibrary().replaceAlertMethod(driver, element);
                 return found.apply(element);
             } catch (StaleElementReferenceException e) {
                 continue;

--- a/src/main/java/jp/vmi/selenium/selenese/command/ContextMenu.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/ContextMenu.java
@@ -26,7 +26,8 @@ public class ContextMenu extends AbstractCommand {
         String locator = curArgs[ARG_LOCATOR];
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         new Actions(driver).moveToElement(element).contextClick().perform();
         return SUCCESS;
     }

--- a/src/main/java/jp/vmi/selenium/selenese/command/SelectElement.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/SelectElement.java
@@ -37,7 +37,8 @@ public class SelectElement {
         WebDriver driver = context.getWrappedDriver();
         finder = context.getElementFinder();
         select = finder.findElement(driver, selectLocator);
-        context.getJSLibrary().replaceAlertMethod(driver, select);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, select);
         selectUI = new Select(select);
         isMultiple = selectUI.isMultiple();
     }

--- a/src/main/java/jp/vmi/selenium/selenese/command/Submit.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Submit.java
@@ -25,7 +25,8 @@ public class Submit extends AbstractCommand {
         String locator = curArgs[ARG_LOCATOR];
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         element.submit();
         return SUCCESS;
     }

--- a/src/main/java/jp/vmi/selenium/selenese/command/Type.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Type.java
@@ -37,7 +37,8 @@ public class Type extends AbstractCommand {
             value = value.toUpperCase();
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         String tagName = element.getTagName().toLowerCase();
         Result result = SUCCESS;
         switch (tagName) {

--- a/src/main/java/jp/vmi/selenium/selenese/command/TypeKeys.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/TypeKeys.java
@@ -36,7 +36,8 @@ public class TypeKeys extends AbstractCommand {
         value = value.replace("\\39", Keys.ARROW_RIGHT);
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         element.sendKeys(value);
         return SUCCESS;
     }

--- a/src/main/java/jp/vmi/selenium/selenese/command/Uncheck.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/Uncheck.java
@@ -25,7 +25,8 @@ public class Uncheck extends AbstractCommand {
         String locator = curArgs[ARG_LOCATOR];
         WebDriver driver = context.getWrappedDriver();
         WebElement element = context.getElementFinder().findElement(driver, locator);
-        context.getJSLibrary().replaceAlertMethod(driver, element);
+        if (context.isReplaceAlertMethod())
+            context.getJSLibrary().replaceAlertMethod(driver, element);
         if (element.isSelected())
             element.click();
         return SUCCESS;

--- a/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/DefaultConfig.java
@@ -236,6 +236,9 @@ public class DefaultConfig implements IConfig {
     @Option(name = "--" + MAX_TIME, metaVar = "<max-time>", usage = "Maximum time in seconds that you allow the entire operation to take.")
     private String maxTime;
 
+    @Option(name = "--" + NO_REPLACE_ALERT_METHOD, usage = "disable replacement of alert methods")
+    private Boolean noReplaceAlertMethod;
+
     @Option(name = "--" + HELP, aliases = "-h", usage = "show this message.")
     private Boolean help;
 
@@ -686,6 +689,15 @@ public class DefaultConfig implements IConfig {
 
     public void setMaxTime(String maxTime) {
         this.maxTime = maxTime;
+    }
+
+    @Override
+    public boolean isNoReplaceAlertMethod() {
+        return noReplaceAlertMethod != null ? noReplaceAlertMethod : (parentOptions != null ? parentOptions.isNoReplaceAlertMethod() : false);
+    }
+
+    public void setNoReplaceAlertMethod(boolean noReplaceAlertMethod) {
+        this.noReplaceAlertMethod = noReplaceAlertMethod;
     }
 
     @Override

--- a/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
+++ b/src/main/java/jp/vmi/selenium/selenese/config/IConfig.java
@@ -74,6 +74,7 @@ public interface IConfig {
     public static final String NO_EXIT = "no-exit";
     public static final String STRICT_EXIT_CODE = "strict-exit-code";
     public static final String MAX_TIME = "max-time";
+    public static final String NO_REPLACE_ALERT_METHOD = "no-replace-alert-method";
     public static final String HELP = "help";
 
     // ### END OPTION NAMES GENERATED FROM config.groovy (*** DO NOT EDIT DIRECTLY ***)
@@ -199,6 +200,8 @@ public interface IConfig {
     boolean isStrictExitCode();
 
     String getMaxTime();
+
+    boolean isNoReplaceAlertMethod();
 
     boolean isHelp();
 

--- a/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
@@ -489,4 +489,15 @@ public class DriverDependentTest extends DriverDependentTestCaseTestBase {
         execute("testcase_ie");
         assertThat(result, is(instanceOf(Success.class)));
     }
+
+    @Test
+    public void testNoReplaceAlertMethod() {
+        assumeNot(PHANTOMJS);
+        runner.setReplaceAlertMethod(false);
+
+        execute("testcase_no_replace_alert_method");
+        assertThat(result, is(instanceOf(Success.class)));
+
+        runner.setReplaceAlertMethod(true);
+    }
 }

--- a/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/config/DefaultConfigTest.java
@@ -53,7 +53,8 @@ public class DefaultConfigTest {
         "--" + ALERTS_POLICY + "=dismiss",
         "--" + COOKIE_FILTER + "=^OPT_SID",
         "--" + COMMAND_FACTORY + "=opt.full.qualify.class.Name",
-        "--" + LOG_FILTER + "=-cookie"
+        "--" + LOG_FILTER + "=-cookie",
+        "--" + NO_REPLACE_ALERT_METHOD
     };
 
     @Test
@@ -97,6 +98,7 @@ public class DefaultConfigTest {
         assertThat(config.get(COMMAND_FACTORY), is(nullValue()));
         assertThat(config.get(LOG_FILTER), is(nullValue()));
         assertThat(config.getArgs(), is(emptyArray()));
+        assertThat(config.get(NO_REPLACE_ALERT_METHOD), is(false));
     }
 
     @Test
@@ -140,6 +142,7 @@ public class DefaultConfigTest {
         assertThat((String) config.get(COOKIE_FILTER), is("^SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("full.qualify.class.Name"));
         assertThat(config.getLogFilter(), equalTo(new String[] { "-pageinfo", "+title", "+url" }));
+        assertThat(config.isNoReplaceAlertMethod(), is(true));
     }
 
     @Test
@@ -184,5 +187,6 @@ public class DefaultConfigTest {
         assertThat((String) config.get(COOKIE_FILTER), is("^OPT_SID"));
         assertThat((String) config.get(COMMAND_FACTORY), is("opt.full.qualify.class.Name"));
         assertThat(config.getLogFilter(), equalTo(new String[] { "-cookie" }));
+        assertThat(config.isNoReplaceAlertMethod(), is(true));
     }
 }

--- a/src/test/java/jp/vmi/selenium/testutils/WebServer.java
+++ b/src/test/java/jp/vmi/selenium/testutils/WebServer.java
@@ -1,6 +1,7 @@
 package jp.vmi.selenium.testutils;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -110,7 +111,10 @@ public class WebServer {
      */
     public WebServer(int port, String htdocs) {
         this.port = port;
-        this.htdocs = htdocs != null ? htdocs : WebServer.class.getResource("/htdocs").getFile();
+        if (htdocs == null)
+            htdocs = WebServer.class.getResource("/htdocs").getFile();
+        // convert to correct local path (required for windows)
+        this.htdocs = new File(htdocs).getPath();
     }
 
     private static class HttpErrorException extends Exception {

--- a/src/test/resources/config/test.config
+++ b/src/test/resources/config/test.config
@@ -45,3 +45,4 @@ log-filter:
   -pageinfo
   +title
   +url
+no-replace-alert-method: true

--- a/src/test/resources/selenese/testcase_no_replace_alert_method.html
+++ b/src/test/resources/selenese/testcase_no_replace_alert_method.html
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>testcase_no_replace_alert_method</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">testcase_no_replace_alert_method</td></tr>
+</thead><tbody>
+<tr>
+	<td>open</td>
+	<td>/dialog_override.html</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=alert</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlert</td>
+	<td>open alert dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=alert_result</td>
+	<td>done.</td>
+</tr>
+<tr>
+	<td>verifyNativeAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>answerOnNextNativeAlert</td>
+	<td>prompt answer.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=prompt</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlert</td>
+	<td>open prompt dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=prompt_result</td>
+	<td>prompt answer.</td>
+</tr>
+<tr>
+	<td>verifyNativeAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseOkOnNextNativeAlert</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=confirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlert</td>
+	<td>open confirm dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=confirm_result</td>
+	<td>true</td>
+</tr>
+<tr>
+	<td>verifyNativeAlertNotPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>chooseCancelOnNextNativeAlert</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=confirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlertPresent</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNativeAlert</td>
+	<td>open confirm dialog.</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyText</td>
+	<td>id=confirm_result</td>
+	<td>false</td>
+</tr>
+</tbody></table>
+</body>
+</html>


### PR DESCRIPTION
### Summary

Add option to disable `replaceAlertMethod` so that selenese-runner-java can be used even on sites where `replaceAlertMethod` does not work properly.

### Description

I'm facing an issue where an alert dialog related command fails at one unpublished site.

On this site, `JSON.parse` failed to convert stringified array back to an array object due to the strange behavior of the  `JSON.stringify` that array always seems to be converted into string twice
(For example, an empty array is converted to a 4 character string `"[]"` and `JSON.parse` convert it as 2 character string `[]`)

I tried replacing the implementation of `JSON.stringify` with [another one](https://github.com/douglascrockford/JSON-js), but array was still converted incorrectly.

Even for such a case, we can handle the alert dialogs using the `*NativeAlert` commands as long as we don't replace the alert functions.

This PR adds an option for that.

