### PR TITLE
ExecuteAsyncScript: Only check for thenable #332 

### DIFF
--- a/src/main/java/jp/vmi/selenium/selenese/command/ExecuteAsyncScript.java
+++ b/src/main/java/jp/vmi/selenium/selenese/command/ExecuteAsyncScript.java
@@ -32,7 +32,7 @@ public class ExecuteAsyncScript extends AbstractCommand {
     protected Result executeImpl(Context context, String... curArgs) {
         String script = "(function(callback) {"
             + "  var promise = (function() {" + curArgs[ARG_SCRIPT] + "})();"
-            + "  if (Promise.resolve(promise) === promise) {"
+            + "  if (!!promise && typeof promise.then === 'function') {"
             + "    promise.then(res => callback({ isPromise: true, isResolved: true,  value: res }),"
             + "                 rej => callback({ isPromise: true, isResolved: false, value: rej }));"
             + "  } else {"

--- a/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
+++ b/src/test/java/jp/vmi/selenium/selenese/DriverDependentTest.java
@@ -451,6 +451,37 @@ public class DriverDependentTest extends DriverDependentTestCaseTestBase {
     }
 
     @Test
+    public void testExecuteAsyncScriptSuccess() {
+        assumeNot(IE);
+        execute("testcase_execute_async_script_success.side");
+        assertThat(result, is(instanceOf(Success.class)));
+    }
+
+    @Test
+    public void testExecuteAsyncScriptReject() {
+        assumeNot(IE);
+        execute("testcase_execute_async_script_reject.side");
+        assertThat(result, is(instanceOf(Failure.class)));
+        assertThat(result.getMessage(), containsString("NG"));
+    }
+
+    @Test
+    public void testExecuteAsyncScriptRejectPage() {
+        assumeNot(IE);
+        execute("testcase_execute_async_script_reject_page.side");
+        assertThat(result, is(instanceOf(Failure.class)));
+        assertThat(result.getMessage(), containsString("NG from page"));
+    }
+
+    @Test
+    public void testExecuteAsyncScriptNotAPromise() {
+        assumeNot(IE);
+        execute("testcase_execute_async_script_not_a_promise.side");
+        assertThat(result, is(instanceOf(Error.class)));
+        assertThat(result.getMessage(), containsString("Expected async operation, instead received: not Promise"));
+    }
+
+    @Test
     public void testSide() {
         execute("testsuite_simple.side");
         assertThat(result, is(instanceOf(Success.class)));

--- a/src/test/resources/htdocs/execute_async_script.html
+++ b/src/test/resources/htdocs/execute_async_script.html
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://localhost/" />
+<title>Execute Async Script</title>
+</head>
+<body>
+<h1>Execute async script</h1>
+<script>
+window.createResolvedPromise = () => Promise.resolve("OK from page")
+window.createRejectedPromise = () => Promise.reject("NG from page")
+</script>
+</body>
+</html>

--- a/src/test/resources/selenese/testcase_execute_async_script_not_a_promise.side
+++ b/src/test/resources/selenese/testcase_execute_async_script_not_a_promise.side
@@ -1,0 +1,35 @@
+{
+  "id": "73bfe695-bbf9-4da8-863c-e83d4306b381",
+  "version": "2.0",
+  "name": "testcase_execute_async_script_not_a_promise",
+  "url": "http://localhost",
+  "tests": [{
+    "id": "54eb5380-41f3-4d9b-a036-8a0c1858945c",
+    "name": "01not_promise",
+    "commands": [{
+      "id": "cd4ff04e-4e3d-46fe-8d25-c86998b2b893",
+      "comment": "",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "e36628d6-3cd3-4d0f-bf38-1ec9c7d60a7f",
+      "comment": "",
+      "command": "executeAsyncScript",
+      "target": "return \"not Promise\"",
+      "targets": [],
+      "value": "value"
+    }]
+  }],
+  "suites": [{
+    "id": "0a569033-8369-4741-965d-01cd83dd6bfc",
+    "name": "testcase_execute_async_script_not_a_promise",
+    "persistSession": false,
+    "parallel": false,
+    "timeout": 300,
+    "tests": ["54eb5380-41f3-4d9b-a036-8a0c1858945c"]
+  }],
+  "urls": ["http://localhost/"],
+  "plugins": []
+}

--- a/src/test/resources/selenese/testcase_execute_async_script_reject.side
+++ b/src/test/resources/selenese/testcase_execute_async_script_reject.side
@@ -1,0 +1,35 @@
+{
+  "id": "73bfe695-bbf9-4da8-863c-e83d4306b381",
+  "version": "2.0",
+  "name": "testcase_execute_async_script_reject",
+  "url": "http://localhost",
+  "tests": [{
+    "id": "0fcc357c-c8d6-4f11-8e8d-98119bf59d04",
+    "name": "01reject",
+    "commands": [{
+      "id": "67abc760-6aec-4584-8d1a-53ea9130aec1",
+      "comment": "",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "ff135346-483f-4b44-afb4-ded6c4824f9b",
+      "comment": "",
+      "command": "executeAsyncScript",
+      "target": "return Promise.reject(\"NG\")",
+      "targets": [],
+      "value": "value"
+    }]
+  }],
+  "suites": [{
+    "id": "0a569033-8369-4741-965d-01cd83dd6bfc",
+    "name": "testcase_execute_async_script_reject",
+    "persistSession": false,
+    "parallel": false,
+    "timeout": 300,
+    "tests": ["0fcc357c-c8d6-4f11-8e8d-98119bf59d04"]
+  }],
+  "urls": ["http://localhost/"],
+  "plugins": []
+}

--- a/src/test/resources/selenese/testcase_execute_async_script_reject_page.side
+++ b/src/test/resources/selenese/testcase_execute_async_script_reject_page.side
@@ -1,0 +1,42 @@
+{
+  "id": "73bfe695-bbf9-4da8-863c-e83d4306b381",
+  "version": "2.0",
+  "name": "testcase_execute_async_script_reject_page",
+  "url": "http://localhost",
+  "tests": [{
+    "id": "229124e3-8b0b-42bc-bb5d-101dbb4c08b5",
+    "name": "01promise_from_page_script",
+    "commands": [{
+      "id": "8ddfbeca-1bf3-4cba-a1a9-a000e83457d6",
+      "comment": "",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "7e7b58ca-4b03-4341-b0ac-f73629475fb9",
+      "comment": "Open execute async test page.",
+      "command": "clickAt",
+      "target": "//a[contains(text(),'Execute Async Script')]",
+      "targets": [],
+      "value": "44,8"
+    }, {
+      "id": "34c30b48-a00a-4a86-a1bc-e97cb08ec2f8",
+      "comment": "",
+      "command": "executeAsyncScript",
+      "target": "return window.createRejectedPromise()",
+      "targets": [],
+      "value": "value"
+    }]
+  }],
+  "suites": [{
+    "id": "0a569033-8369-4741-965d-01cd83dd6bfc",
+    "name": "testcase_execute_async_script_reject_page",
+    "persistSession": false,
+    "parallel": false,
+    "timeout": 300,
+    "tests": ["229124e3-8b0b-42bc-bb5d-101dbb4c08b5"]
+  }],
+  "urls": ["http://localhost/"],
+  "plugins": []
+}

--- a/src/test/resources/selenese/testcase_execute_async_script_success.side
+++ b/src/test/resources/selenese/testcase_execute_async_script_success.side
@@ -1,0 +1,74 @@
+{
+  "id": "73bfe695-bbf9-4da8-863c-e83d4306b381",
+  "version": "2.0",
+  "name": "testcase_execute_async_script",
+  "url": "http://localhost",
+  "tests": [{
+    "id": "8f50bf34-2619-42cf-90e1-b6e51c2c6bfb",
+    "name": "01resolve",
+    "commands": [{
+      "id": "5d4fbdf6-46eb-4b86-8c9a-0a36b6763436",
+      "comment": "",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "08869254-3e9c-40dd-9c23-bb6a9462e125",
+      "comment": "",
+      "command": "executeAsyncScript",
+      "target": "return Promise.resolve(\"OK\")",
+      "targets": [],
+      "value": "value"
+    }, {
+      "id": "a1418761-2cc3-44e9-befa-16890b224abf",
+      "comment": "",
+      "command": "assert",
+      "target": "value",
+      "targets": [],
+      "value": "OK"
+    }]
+  }, {
+    "id": "15b85f22-166d-439f-846b-e87775641daa",
+    "name": "02promise_from_page_script",
+    "commands": [{
+      "id": "2cd38d26-24f2-4577-8c21-e26db5a86a8b",
+      "comment": "",
+      "command": "open",
+      "target": "/",
+      "targets": [],
+      "value": ""
+    }, {
+      "id": "695fa70d-33fd-4cb4-bd8d-eb53d0fafce4",
+      "comment": "Open execute async test page.",
+      "command": "clickAt",
+      "target": "//a[contains(text(),'Execute Async Script')]",
+      "targets": [],
+      "value": "44,8"
+    }, {
+      "id": "9861288f-11c3-4814-9228-4205e7e97aec",
+      "comment": "",
+      "command": "executeAsyncScript",
+      "target": "return window.createResolvedPromise()",
+      "targets": [],
+      "value": "value"
+    }, {
+      "id": "df3580dc-e048-40ea-b532-9553a1a2007b",
+      "comment": "",
+      "command": "assert",
+      "target": "value",
+      "targets": [],
+      "value": "OK from page"
+    }]
+  }],
+  "suites": [{
+    "id": "0a569033-8369-4741-965d-01cd83dd6bfc",
+    "name": "testcase_execute_async_script_success",
+    "persistSession": false,
+    "parallel": false,
+    "timeout": 300,
+    "tests": ["8f50bf34-2619-42cf-90e1-b6e51c2c6bfb", "15b85f22-166d-439f-846b-e87775641daa"]
+  }],
+  "urls": ["http://localhost/"],
+  "plugins": []
+}


### PR DESCRIPTION
* Fixes #332, see there for more details
* Add test cases for `executeAsyncScript` to illustrate the issue with Firefox
* Only check whether promise is thenable, e.g. whether it is truthy and has a `then` property of type `function`