### PR TITLE
Updated remote grid configuration

### DIFF
--- a/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
+++ b/src/main/java/jp/vmi/selenium/webdriver/RemoteWebDriverFactory.java
@@ -31,7 +31,8 @@ public class RemoteWebDriverFactory extends WebDriverFactory {
 
     @Override
     public WebDriver newInstance(DriverOptions driverOptions) {
-        DesiredCapabilities caps = new DesiredCapabilities(getBrowserName(), "", Platform.ANY);
+        DesiredCapabilities caps = new DesiredCapabilities();
+        caps.setBrowserName(getBrowserName());
         setupProxy(caps, driverOptions);
         caps.merge(driverOptions.getCapabilities());
         if (driverOptions.has(REMOTE_BROWSER)) {


### PR DESCRIPTION
When using the remote grid, it is best not to include anything unless you are specifically setting it, like browser version, and platform. If you just send browser then it works with nothing else. The way it was, you had to very explicit to get it to work by specifying the exact browser version and platform